### PR TITLE
Add Rust adapters and CLI configuration testing

### DIFF
--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -9,3 +9,10 @@ path = "src/lib.rs"
 
 [dependencies]
 novel-core = { path = "../core" }
+reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+regex = "1"
+once_cell = "1"
+log = "0.4"

--- a/crates/adapters/src/base_url.rs
+++ b/crates/adapters/src/base_url.rs
@@ -1,0 +1,73 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static VERSION_SUFFIX_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"/v\d+$").unwrap());
+
+pub fn check_base_url(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if trimmed.ends_with('#') {
+        return trimmed.trim_end_matches('#').to_string();
+    }
+
+    if !VERSION_SUFFIX_RE.is_match(trimmed) && !trimmed.contains("/v1") {
+        let without_slash = trimmed.trim_end_matches('/');
+        format!("{}/v1", without_slash)
+    } else {
+        trimmed.to_string()
+    }
+}
+
+pub fn ensure_openai_base_url_has_v1(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if VERSION_SUFFIX_RE.is_match(trimmed) || trimmed.contains("/v1") {
+        trimmed.to_string()
+    } else {
+        let without_slash = trimmed.trim_end_matches('/');
+        format!("{}/v1", without_slash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_base_url_appends_v1_when_missing() {
+        assert_eq!(
+            check_base_url("https://example.com"),
+            "https://example.com/v1"
+        );
+    }
+
+    #[test]
+    fn check_base_url_keeps_existing_version() {
+        assert_eq!(
+            check_base_url("https://example.com/v2"),
+            "https://example.com/v2"
+        );
+    }
+
+    #[test]
+    fn check_base_url_respects_hash_suffix() {
+        assert_eq!(
+            check_base_url("https://example.com/#"),
+            "https://example.com/"
+        );
+    }
+
+    #[test]
+    fn ensure_base_url_appends_v1() {
+        assert_eq!(
+            ensure_openai_base_url_has_v1("https://example.com"),
+            "https://example.com/v1"
+        );
+    }
+}

--- a/crates/adapters/src/embedding.rs
+++ b/crates/adapters/src/embedding.rs
@@ -1,0 +1,456 @@
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use reqwest::blocking::Client;
+use reqwest::header::{self, HeaderMap, HeaderValue};
+use serde::Deserialize;
+
+use novel_core::config::{Config, EmbeddingConfig};
+
+use crate::base_url::ensure_openai_base_url_has_v1;
+use crate::error::AdapterError;
+use crate::retry::{call_with_retry, RetryConfig};
+
+pub trait EmbeddingModel: Send + Sync {
+    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, AdapterError>;
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>, AdapterError>;
+}
+
+pub fn create_embedding_adapter(
+    config: &Config,
+    profile_name: &str,
+) -> Result<Box<dyn EmbeddingModel>, AdapterError> {
+    let profile = config.get_embedding_profile(profile_name).ok_or_else(|| {
+        AdapterError::InvalidConfig(format!("unknown embedding profile `{}`", profile_name))
+    })?;
+    create_embedding_adapter_from_profile(profile)
+}
+
+pub fn create_embedding_adapter_from_profile(
+    profile: &EmbeddingConfig,
+) -> Result<Box<dyn EmbeddingModel>, AdapterError> {
+    let fmt = profile.interface_format.trim().to_lowercase();
+
+    match fmt.as_str() {
+        "openai" => Ok(Box::new(OpenAiEmbeddingAdapter::new(
+            optional_string(&profile.api_key),
+            &profile.base_url,
+            &profile.model_name,
+        )?)),
+        "azure openai" => Ok(Box::new(AzureOpenAiEmbeddingAdapter::new(
+            profile.api_key.clone(),
+            &profile.base_url,
+        )?)),
+        "ollama" => Ok(Box::new(OllamaEmbeddingAdapter::new(
+            &profile.base_url,
+            &profile.model_name,
+        )?)),
+        "ml studio" => Ok(Box::new(OpenAiEmbeddingAdapter::new(
+            optional_string(&profile.api_key),
+            &profile.base_url,
+            &profile.model_name,
+        )?)),
+        "gemini" => Ok(Box::new(GeminiEmbeddingAdapter::new(
+            profile.api_key.clone(),
+            &profile.base_url,
+            &profile.model_name,
+        )?)),
+        "siliconflow" => Ok(Box::new(OpenAiEmbeddingAdapter::new(
+            optional_string(&profile.api_key),
+            &profile.base_url,
+            &profile.model_name,
+        )?)),
+        other => Err(AdapterError::InvalidConfig(format!(
+            "unknown embedding interface_format: {}",
+            other
+        ))),
+    }
+}
+
+fn optional_string(value: &str) -> Option<String> {
+    if value.trim().is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+struct OpenAiEmbeddingAdapter {
+    client: Client,
+    url: String,
+    api_key: Option<String>,
+    model_name: String,
+    retry: RetryConfig,
+}
+
+impl OpenAiEmbeddingAdapter {
+    fn new(
+        api_key: Option<String>,
+        base_url: &str,
+        model_name: &str,
+    ) -> Result<Self, AdapterError> {
+        if model_name.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "embedding model_name must not be empty".to_string(),
+            ));
+        }
+
+        let normalized = ensure_openai_base_url_has_v1(if base_url.trim().is_empty() {
+            "https://api.openai.com"
+        } else {
+            base_url
+        });
+
+        let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
+
+        Ok(Self {
+            client,
+            url: format!("{}/embeddings", normalized.trim_end_matches('/')),
+            api_key,
+            model_name: model_name.to_string(),
+            retry: RetryConfig::default(),
+        })
+    }
+
+    fn embed(&self, input: serde_json::Value) -> Result<Vec<Vec<f32>>, AdapterError> {
+        let mut request = self.client.post(&self.url).header(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+
+        if let Some(key) = &self.api_key {
+            if !key.is_empty() {
+                request = request.bearer_auth(key);
+            }
+        }
+
+        let payload = serde_json::json!({
+            "model": self.model_name,
+            "input": input,
+        });
+
+        let response = request.json(&payload).send()?;
+        handle_openai_embedding_response(response)
+    }
+}
+
+impl EmbeddingModel for OpenAiEmbeddingAdapter {
+    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, AdapterError> {
+        call_with_retry(
+            || {
+                let inputs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+                self.embed(serde_json::Value::from(inputs))
+            },
+            &self.retry,
+        )
+    }
+
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>, AdapterError> {
+        let vectors = call_with_retry(
+            || self.embed(serde_json::Value::from(vec![text])),
+            &self.retry,
+        )?;
+        vectors
+            .into_iter()
+            .next()
+            .ok_or(AdapterError::EmptyResponse)
+    }
+}
+
+struct AzureOpenAiEmbeddingAdapter {
+    client: Client,
+    url: String,
+    api_key: String,
+    retry: RetryConfig,
+}
+
+impl AzureOpenAiEmbeddingAdapter {
+    fn new(api_key: String, base_url: &str) -> Result<Self, AdapterError> {
+        if api_key.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Azure OpenAI embedding api_key must not be empty".to_string(),
+            ));
+        }
+
+        static AZURE_RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
+                r"^https://([^/]+)/openai/deployments/([^/]+)/embeddings\?api-version=([^/?&]+)",
+            )
+            .unwrap()
+        });
+
+        let base = base_url.trim();
+        let captures = AZURE_RE.captures(base).ok_or_else(|| {
+            AdapterError::InvalidConfig(
+                "Invalid Azure OpenAI embedding base_url. Expected https://<resource>.openai.azure.com/openai/deployments/<deployment>/embeddings?api-version=<version>"
+                    .to_string(),
+            )
+        })?;
+
+        let endpoint = format!("https://{}", &captures[1]);
+        let deployment = captures[2].to_string();
+        let api_version = captures[3].to_string();
+
+        let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
+
+        Ok(Self {
+            client,
+            url: format!(
+                "{endpoint}/openai/deployments/{deployment}/embeddings?api-version={api_version}"
+            ),
+            api_key,
+            retry: RetryConfig::default(),
+        })
+    }
+
+    fn embed(&self, input: serde_json::Value) -> Result<Vec<Vec<f32>>, AdapterError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            "api-key",
+            HeaderValue::from_str(&self.api_key).map_err(|err| {
+                AdapterError::InvalidConfig(format!("invalid api key header: {}", err))
+            })?,
+        );
+
+        let payload = serde_json::json!({
+            "input": input,
+        });
+
+        let response = self
+            .client
+            .post(&self.url)
+            .headers(headers)
+            .json(&payload)
+            .send()?;
+        handle_openai_embedding_response(response)
+    }
+}
+
+impl EmbeddingModel for AzureOpenAiEmbeddingAdapter {
+    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, AdapterError> {
+        call_with_retry(
+            || {
+                let inputs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+                self.embed(serde_json::Value::from(inputs))
+            },
+            &self.retry,
+        )
+    }
+
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>, AdapterError> {
+        let vectors = call_with_retry(
+            || self.embed(serde_json::Value::from(vec![text])),
+            &self.retry,
+        )?;
+        vectors
+            .into_iter()
+            .next()
+            .ok_or(AdapterError::EmptyResponse)
+    }
+}
+
+struct OllamaEmbeddingAdapter {
+    client: Client,
+    url: String,
+    model_name: String,
+    retry: RetryConfig,
+}
+
+impl OllamaEmbeddingAdapter {
+    fn new(base_url: &str, model_name: &str) -> Result<Self, AdapterError> {
+        if base_url.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Ollama embedding base_url must not be empty".to_string(),
+            ));
+        }
+
+        if model_name.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Ollama embedding model_name must not be empty".to_string(),
+            ));
+        }
+
+        let url = normalize_ollama_url(base_url);
+
+        let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
+
+        Ok(Self {
+            client,
+            url,
+            model_name: model_name.to_string(),
+            retry: RetryConfig::default(),
+        })
+    }
+
+    fn embed_once(&self, text: &str) -> Result<Vec<f32>, AdapterError> {
+        let payload = serde_json::json!({
+            "model": self.model_name,
+            "prompt": text,
+        });
+
+        let response = self.client.post(&self.url).json(&payload).send()?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().unwrap_or_default();
+            return Err(AdapterError::HttpStatus { status, body });
+        }
+
+        let parsed: OllamaEmbeddingResponse = response.json()?;
+        parsed
+            .embedding
+            .map(|values| values.into_iter().map(|v| v as f32).collect())
+            .ok_or(AdapterError::EmptyResponse)
+    }
+}
+
+impl EmbeddingModel for OllamaEmbeddingAdapter {
+    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, AdapterError> {
+        let mut embeddings = Vec::with_capacity(texts.len());
+        for text in texts {
+            let vector = call_with_retry(|| self.embed_once(text), &self.retry)?;
+            embeddings.push(vector);
+        }
+        Ok(embeddings)
+    }
+
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>, AdapterError> {
+        call_with_retry(|| self.embed_once(text), &self.retry)
+    }
+}
+
+struct GeminiEmbeddingAdapter {
+    client: Client,
+    url: String,
+    retry: RetryConfig,
+}
+
+impl GeminiEmbeddingAdapter {
+    fn new(api_key: String, base_url: &str, model_name: &str) -> Result<Self, AdapterError> {
+        if api_key.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Gemini embedding api_key must not be empty".to_string(),
+            ));
+        }
+
+        if model_name.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Gemini embedding model_name must not be empty".to_string(),
+            ));
+        }
+
+        let base = if base_url.trim().is_empty() {
+            "https://generativelanguage.googleapis.com/v1beta".to_string()
+        } else {
+            base_url.trim().trim_end_matches('/').to_string()
+        };
+
+        let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
+
+        Ok(Self {
+            client,
+            url: format!(
+                "{base}/models/{model}:embedContent?key={api}",
+                model = model_name,
+                api = api_key
+            ),
+            retry: RetryConfig::default(),
+        })
+    }
+
+    fn embed_once(&self, text: &str) -> Result<Vec<f32>, AdapterError> {
+        let payload = serde_json::json!({
+            "content": {
+                "parts": [ { "text": text } ]
+            }
+        });
+
+        let response = self.client.post(&self.url).json(&payload).send()?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().unwrap_or_default();
+            return Err(AdapterError::HttpStatus { status, body });
+        }
+
+        let parsed: GeminiEmbeddingResponse = response.json()?;
+        parsed
+            .embedding
+            .map(|values| values.into_iter().map(|v| v as f32).collect())
+            .ok_or(AdapterError::EmptyResponse)
+    }
+}
+
+impl EmbeddingModel for GeminiEmbeddingAdapter {
+    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, AdapterError> {
+        let mut embeddings = Vec::with_capacity(texts.len());
+        for text in texts {
+            let vector = call_with_retry(|| self.embed_once(text), &self.retry)?;
+            embeddings.push(vector);
+        }
+        Ok(embeddings)
+    }
+
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>, AdapterError> {
+        call_with_retry(|| self.embed_once(text), &self.retry)
+    }
+}
+
+fn normalize_ollama_url(base_url: &str) -> String {
+    let mut url = base_url.trim().trim_end_matches('/').to_string();
+    if !url.contains("/api/embeddings") {
+        if url.contains("/api") {
+            url.push_str("/embeddings");
+        } else {
+            if let Some(index) = url.find("/v1") {
+                url.truncate(index);
+            }
+            url.push_str("/api/embeddings");
+        }
+    }
+    url
+}
+
+fn handle_openai_embedding_response(
+    response: reqwest::blocking::Response,
+) -> Result<Vec<Vec<f32>>, AdapterError> {
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().unwrap_or_default();
+        return Err(AdapterError::HttpStatus { status, body });
+    }
+
+    let parsed: OpenAiEmbeddingResponse = response.json()?;
+    let vectors = parsed
+        .data
+        .into_iter()
+        .map(|item| item.embedding.into_iter().map(|v| v as f32).collect())
+        .collect::<Vec<Vec<f32>>>();
+    if vectors.is_empty() {
+        return Err(AdapterError::EmptyResponse);
+    }
+    Ok(vectors)
+}
+
+#[derive(Deserialize)]
+struct OpenAiEmbeddingResponse {
+    data: Vec<OpenAiEmbeddingData>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiEmbeddingData {
+    embedding: Vec<f64>,
+}
+
+#[derive(Deserialize)]
+struct OllamaEmbeddingResponse {
+    embedding: Option<Vec<f64>>,
+}
+
+#[derive(Deserialize)]
+struct GeminiEmbeddingResponse {
+    embedding: Option<Vec<f64>>,
+}

--- a/crates/adapters/src/error.rs
+++ b/crates/adapters/src/error.rs
@@ -1,0 +1,31 @@
+use reqwest::StatusCode;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AdapterError {
+    #[error("http request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("failed to parse response: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid adapter configuration: {0}")]
+    InvalidConfig(String),
+    #[error("unexpected http status {status}: {body}")]
+    HttpStatus { status: StatusCode, body: String },
+    #[error("operation failed after {attempts} attempts: {source}")]
+    RetryExhausted {
+        attempts: usize,
+        #[source]
+        source: Box<AdapterError>,
+    },
+    #[error("API returned an empty response")]
+    EmptyResponse,
+}
+
+impl AdapterError {
+    pub fn retry_exhausted(attempts: usize, source: AdapterError) -> Self {
+        AdapterError::RetryExhausted {
+            attempts,
+            source: Box::new(source),
+        }
+    }
+}

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -1,3 +1,15 @@
-//! Adapter crate placeholder.
+mod base_url;
+mod embedding;
+mod error;
+mod llm;
+mod retry;
+
+pub use base_url::{check_base_url, ensure_openai_base_url_has_v1};
+pub use embedding::{
+    create_embedding_adapter, create_embedding_adapter_from_profile, EmbeddingModel,
+};
+pub use error::AdapterError;
+pub use llm::{create_llm_adapter, create_llm_adapter_from_profile, LanguageModel};
+pub use retry::{call_with_retry, RetryConfig};
 
 pub use novel_core::config::{Config, ConfigStore, EmbeddingConfig, LlmConfig, NovelConfig};

--- a/crates/adapters/src/llm.rs
+++ b/crates/adapters/src/llm.rs
@@ -1,0 +1,791 @@
+use std::thread;
+use std::time::Duration;
+
+use log::warn;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use reqwest::blocking::Client;
+use reqwest::header::{self, HeaderMap, HeaderValue};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use novel_core::config::{Config, LlmConfig};
+
+use crate::base_url::check_base_url;
+use crate::error::AdapterError;
+use crate::retry::{call_with_retry, RetryConfig};
+
+pub trait LanguageModel: Send + Sync {
+    fn invoke(&self, prompt: &str) -> Result<String, AdapterError>;
+}
+
+pub fn create_llm_adapter(
+    config: &Config,
+    profile_name: &str,
+) -> Result<Box<dyn LanguageModel>, AdapterError> {
+    let profile = config.get_llm_profile(profile_name).ok_or_else(|| {
+        AdapterError::InvalidConfig(format!("unknown LLM profile `{}`", profile_name))
+    })?;
+    create_llm_adapter_from_profile(profile)
+}
+
+pub fn create_llm_adapter_from_profile(
+    profile: &LlmConfig,
+) -> Result<Box<dyn LanguageModel>, AdapterError> {
+    let fmt = profile.interface_format.trim().to_lowercase();
+    let timeout = profile.timeout.max(1);
+
+    match fmt.as_str() {
+        "openai" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, "https://api.openai.com/v1"),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("You are a helpful assistant.".to_string()),
+        )?)),
+        "deepseek" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, "https://api.deepseek.com/v1"),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("You are a helpful assistant.".to_string()),
+        )?)),
+        "ollama" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, "http://localhost:11434/v1"),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("You are a helpful assistant.".to_string()),
+        )?)),
+        "ml studio" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, "http://localhost:5000/v1"),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("You are a helpful assistant.".to_string()),
+        )?)),
+        "阿里云百炼" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, ""),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("You are a helpful assistant.".to_string()),
+        )?)),
+        "火山引擎" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, ""),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("你是DeepSeek，是一个 AI 人工智能助手".to_string()),
+        )?)),
+        "硅基流动" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, ""),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("你是DeepSeek，是一个 AI 人智能助手".to_string()),
+        )?)),
+        "grok" => Ok(Box::new(OpenAiLikeAdapter::new(
+            resolve_base_url(&profile.base_url, "https://api.x.ai/v1"),
+            optional_string(&profile.api_key),
+            profile.model_name.clone(),
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+            Some("You are Grok, created by xAI.".to_string()),
+        )?)),
+        "azure openai" => Ok(Box::new(AzureOpenAiAdapter::new(
+            profile.api_key.clone(),
+            &profile.base_url,
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+        )?)),
+        "azure ai" => Ok(Box::new(AzureAiAdapter::new(
+            profile.api_key.clone(),
+            &profile.base_url,
+            &profile.model_name,
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+        )?)),
+        "gemini" => Ok(Box::new(GeminiAdapter::new(
+            profile.api_key.clone(),
+            &profile.base_url,
+            &profile.model_name,
+            profile.max_tokens,
+            profile.temperature,
+            timeout,
+        )?)),
+        other => Err(AdapterError::InvalidConfig(format!(
+            "unknown interface_format: {}",
+            other
+        ))),
+    }
+}
+
+fn optional_string(value: &str) -> Option<String> {
+    if value.trim().is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn resolve_base_url(base_url: &str, default: &str) -> String {
+    let raw = if base_url.trim().is_empty() {
+        default.to_string()
+    } else {
+        base_url.to_string()
+    };
+    check_base_url(&raw)
+}
+
+struct OpenAiLikeAdapter {
+    client: Client,
+    url: String,
+    api_key: Option<String>,
+    model_name: String,
+    max_tokens: Option<u32>,
+    temperature: f32,
+    system_prompt: Option<String>,
+    retry: RetryConfig,
+}
+
+impl OpenAiLikeAdapter {
+    fn new(
+        base_url: String,
+        api_key: Option<String>,
+        model_name: String,
+        max_tokens: u32,
+        temperature: f32,
+        timeout: u64,
+        system_prompt: Option<String>,
+    ) -> Result<Self, AdapterError> {
+        if base_url.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "base_url must not be empty".to_string(),
+            ));
+        }
+
+        if model_name.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "model_name must not be empty".to_string(),
+            ));
+        }
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(timeout))
+            .build()?;
+
+        Ok(Self {
+            client,
+            url: format!("{}/chat/completions", base_url.trim_end_matches('/')),
+            api_key,
+            model_name,
+            max_tokens: if max_tokens == 0 {
+                None
+            } else {
+                Some(max_tokens)
+            },
+            temperature,
+            system_prompt,
+            retry: RetryConfig::default(),
+        })
+    }
+
+    fn invoke_once(&self, prompt: &str) -> Result<String, AdapterError> {
+        let mut messages: Vec<ChatMessageRequest<'_>> = Vec::new();
+        if let Some(system) = self.system_prompt.as_deref() {
+            messages.push(ChatMessageRequest {
+                role: "system",
+                content: system,
+            });
+        }
+        messages.push(ChatMessageRequest {
+            role: "user",
+            content: prompt,
+        });
+
+        let body = ChatCompletionRequest {
+            model: Some(self.model_name.as_str()),
+            messages,
+            max_tokens: self.max_tokens,
+            max_output_tokens: None,
+            temperature: Some(self.temperature),
+        };
+
+        let mut request = self.client.post(&self.url).header(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+
+        if let Some(key) = &self.api_key {
+            if !key.is_empty() {
+                request = request.bearer_auth(key);
+            }
+        }
+
+        let response = request.json(&body).send()?;
+        handle_chat_response(response)
+    }
+}
+
+impl LanguageModel for OpenAiLikeAdapter {
+    fn invoke(&self, prompt: &str) -> Result<String, AdapterError> {
+        call_with_retry(|| self.invoke_once(prompt), &self.retry)
+    }
+}
+
+struct AzureOpenAiAdapter {
+    client: Client,
+    url: String,
+    api_key: String,
+    max_tokens: Option<u32>,
+    temperature: f32,
+    retry: RetryConfig,
+}
+
+impl AzureOpenAiAdapter {
+    fn new(
+        api_key: String,
+        base_url: &str,
+        max_tokens: u32,
+        temperature: f32,
+        timeout: u64,
+    ) -> Result<Self, AdapterError> {
+        if api_key.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Azure OpenAI api_key must not be empty".to_string(),
+            ));
+        }
+
+        static AZURE_RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
+                r"^https://([^/]+)/openai/deployments/([^/]+)/chat/completions\?api-version=([^/?&]+)"
+            )
+            .unwrap()
+        });
+
+        let base = base_url.trim();
+        let captures = AZURE_RE.captures(base).ok_or_else(|| {
+            AdapterError::InvalidConfig(
+                "Invalid Azure OpenAI base_url format. Expected https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<version>"
+                    .to_string(),
+            )
+        })?;
+
+        let endpoint = format!("https://{}", &captures[1]);
+        let deployment = captures[2].to_string();
+        let api_version = captures[3].to_string();
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(timeout))
+            .build()?;
+
+        Ok(Self {
+            client,
+            url: format!(
+                "{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
+            ),
+            api_key,
+            max_tokens: if max_tokens == 0 { None } else { Some(max_tokens) },
+            temperature,
+            retry: RetryConfig::default(),
+        })
+    }
+
+    fn invoke_once(&self, prompt: &str) -> Result<String, AdapterError> {
+        let messages = vec![ChatMessageRequest {
+            role: "user",
+            content: prompt,
+        }];
+
+        let body = ChatCompletionRequest {
+            model: None,
+            messages,
+            max_tokens: self.max_tokens,
+            max_output_tokens: None,
+            temperature: Some(self.temperature),
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            "api-key",
+            HeaderValue::from_str(&self.api_key).map_err(|err| {
+                AdapterError::InvalidConfig(format!("invalid api key header: {}", err))
+            })?,
+        );
+
+        let response = self
+            .client
+            .post(&self.url)
+            .headers(headers)
+            .json(&body)
+            .send()?;
+        handle_chat_response(response)
+    }
+}
+
+impl LanguageModel for AzureOpenAiAdapter {
+    fn invoke(&self, prompt: &str) -> Result<String, AdapterError> {
+        call_with_retry(|| self.invoke_once(prompt), &self.retry)
+    }
+}
+
+struct AzureAiAdapter {
+    client: Client,
+    url: String,
+    api_key: String,
+    max_tokens: Option<u32>,
+    temperature: f32,
+    retry: RetryConfig,
+}
+
+impl AzureAiAdapter {
+    fn new(
+        api_key: String,
+        base_url: &str,
+        model_name: &str,
+        max_tokens: u32,
+        temperature: f32,
+        timeout: u64,
+    ) -> Result<Self, AdapterError> {
+        if api_key.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Azure AI api_key must not be empty".to_string(),
+            ));
+        }
+
+        static AZURE_AI_RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
+                r"^https://([^.]+)\.services\.ai\.azure\.com(?:/models)?(?:/chat/completions)?(?:\?api-version=([^&]+))?"
+            )
+            .unwrap()
+        });
+
+        let base = base_url.trim();
+        let captures = AZURE_AI_RE.captures(base).ok_or_else(|| {
+            AdapterError::InvalidConfig(
+                "Invalid Azure AI base_url format. Expected https://<endpoint>.services.ai.azure.com/models/<model>/chat/completions?api-version=xxx"
+                    .to_string(),
+            )
+        })?;
+
+        let endpoint = format!("https://{}.services.ai.azure.com", &captures[1]);
+        let api_version = captures
+            .get(2)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_else(|| "2024-05-01-preview".to_string());
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(timeout))
+            .build()?;
+
+        Ok(Self {
+            client,
+            url: format!(
+                "{endpoint}/models/{model_name}/chat/completions?api-version={api_version}"
+            ),
+            api_key,
+            max_tokens: if max_tokens == 0 {
+                None
+            } else {
+                Some(max_tokens)
+            },
+            temperature,
+            retry: RetryConfig::default(),
+        })
+    }
+
+    fn invoke_once(&self, prompt: &str) -> Result<String, AdapterError> {
+        let messages = vec![ChatMessageRequest {
+            role: "user",
+            content: prompt,
+        }];
+
+        let body = ChatCompletionRequest {
+            model: None,
+            messages,
+            max_tokens: self.max_tokens,
+            max_output_tokens: self.max_tokens,
+            temperature: Some(self.temperature),
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            "api-key",
+            HeaderValue::from_str(&self.api_key).map_err(|err| {
+                AdapterError::InvalidConfig(format!("invalid api key header: {}", err))
+            })?,
+        );
+
+        let response = self
+            .client
+            .post(&self.url)
+            .headers(headers)
+            .json(&body)
+            .send()?;
+        handle_chat_response(response)
+    }
+}
+
+impl LanguageModel for AzureAiAdapter {
+    fn invoke(&self, prompt: &str) -> Result<String, AdapterError> {
+        call_with_retry(|| self.invoke_once(prompt), &self.retry)
+    }
+}
+
+struct GeminiAdapter {
+    client: Client,
+    url: String,
+    temperature: f32,
+    max_tokens: u32,
+    retry: RetryConfig,
+    base_delay: Duration,
+}
+
+impl GeminiAdapter {
+    fn new(
+        api_key: String,
+        base_url: &str,
+        model_name: &str,
+        max_tokens: u32,
+        temperature: f32,
+        timeout: u64,
+    ) -> Result<Self, AdapterError> {
+        if api_key.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Gemini api_key must not be empty".to_string(),
+            ));
+        }
+
+        if model_name.trim().is_empty() {
+            return Err(AdapterError::InvalidConfig(
+                "Gemini model_name must not be empty".to_string(),
+            ));
+        }
+
+        let base = if base_url.trim().is_empty() {
+            "https://generativelanguage.googleapis.com/v1beta".to_string()
+        } else {
+            base_url.trim().trim_end_matches('/').to_string()
+        };
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(timeout))
+            .build()?;
+
+        Ok(Self {
+            client,
+            url: format!(
+                "{base}/models/{model}:generateContent?key={api}",
+                model = model_name,
+                api = api_key
+            ),
+            temperature,
+            max_tokens,
+            retry: RetryConfig::default(),
+            base_delay: Duration::from_secs(5),
+        })
+    }
+
+    fn invoke_once(&self, prompt: &str) -> Result<String, AdapterError> {
+        let request = GeminiRequest {
+            contents: vec![GeminiRequestContent {
+                role: "user",
+                parts: vec![GeminiRequestPart { text: prompt }],
+            }],
+            generation_config: GeminiGenerationConfig {
+                max_output_tokens: self.max_tokens,
+                temperature: self.temperature,
+            },
+        };
+
+        let response = self.client.post(&self.url).json(&request).send()?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().unwrap_or_default();
+            return Err(AdapterError::HttpStatus { status, body });
+        }
+
+        let parsed: GeminiResponse = response.json()?;
+        parse_gemini_response(parsed)
+    }
+
+    fn rate_limit_delay(&self, err: &AdapterError, attempt: usize) -> Option<Duration> {
+        match err {
+            AdapterError::HttpStatus { status, body } => {
+                let lower = body.to_ascii_lowercase();
+                if *status == StatusCode::TOO_MANY_REQUESTS
+                    || lower.contains("quota")
+                    || lower.contains("rate limit")
+                {
+                    if let Some(secs) = parse_retry_delay(body) {
+                        return Some(Duration::from_secs(secs + 5));
+                    }
+                    let multiplier = 1u32.checked_shl(attempt as u32).unwrap_or(1);
+                    return self
+                        .base_delay
+                        .checked_mul(multiplier)
+                        .or(Some(self.base_delay));
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
+impl LanguageModel for GeminiAdapter {
+    fn invoke(&self, prompt: &str) -> Result<String, AdapterError> {
+        let mut last_error = None;
+
+        for attempt in 0..self.retry.max_retries {
+            match self.invoke_once(prompt) {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    let should_retry = attempt + 1 < self.retry.max_retries;
+                    if should_retry {
+                        if let Some(delay) = self.rate_limit_delay(&err, attempt) {
+                            warn!(
+                                "Gemini rate limit encountered, retrying in {:?} (attempt {}/{})",
+                                delay,
+                                attempt + 1,
+                                self.retry.max_retries
+                            );
+                            thread::sleep(delay);
+                            last_error = Some(err);
+                            continue;
+                        }
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
+        let err = last_error.unwrap_or(AdapterError::EmptyResponse);
+        Err(AdapterError::retry_exhausted(self.retry.max_retries, err))
+    }
+}
+
+fn handle_chat_response(response: reqwest::blocking::Response) -> Result<String, AdapterError> {
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().unwrap_or_default();
+        return Err(AdapterError::HttpStatus { status, body });
+    }
+
+    let parsed: ChatCompletionResponse = response.json()?;
+    extract_choice_content(parsed).ok_or(AdapterError::EmptyResponse)
+}
+
+#[derive(Serialize)]
+struct ChatCompletionRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<&'a str>,
+    messages: Vec<ChatMessageRequest<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "max_tokens")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "max_output_tokens")]
+    max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+}
+
+#[derive(Serialize)]
+struct ChatMessageRequest<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionResponse {
+    #[serde(default)]
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    #[serde(default)]
+    message: Option<ChatMessage>,
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatMessage {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+fn extract_choice_content(response: ChatCompletionResponse) -> Option<String> {
+    for choice in response.choices {
+        if let Some(message) = choice.message {
+            if let Some(content) = message.content {
+                if !content.trim().is_empty() {
+                    return Some(content);
+                }
+            }
+        }
+        if let Some(content) = choice.content {
+            if !content.trim().is_empty() {
+                return Some(content);
+            }
+        }
+    }
+    None
+}
+
+#[derive(Serialize)]
+struct GeminiRequest<'a> {
+    contents: Vec<GeminiRequestContent<'a>>,
+    #[serde(rename = "generationConfig")]
+    generation_config: GeminiGenerationConfig,
+}
+
+#[derive(Serialize)]
+struct GeminiRequestContent<'a> {
+    role: &'static str,
+    parts: Vec<GeminiRequestPart<'a>>,
+}
+
+#[derive(Serialize)]
+struct GeminiRequestPart<'a> {
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+struct GeminiGenerationConfig {
+    #[serde(rename = "maxOutputTokens")]
+    max_output_tokens: u32,
+    temperature: f32,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiResponse {
+    #[serde(default)]
+    candidates: Vec<GeminiCandidate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiCandidate {
+    #[serde(default)]
+    content: Option<GeminiContent>,
+    #[serde(rename = "finishReason")]
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiContent {
+    #[serde(default)]
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum GeminiPart {
+    Text { text: String },
+    Other(serde_json::Value),
+}
+
+fn parse_gemini_response(response: GeminiResponse) -> Result<String, AdapterError> {
+    for candidate in response.candidates {
+        if let Some(reason) = candidate.finish_reason.as_deref() {
+            match reason {
+                "MAX_TOKENS" => warn!("Gemini response truncated due to max_tokens limit"),
+                "SAFETY" => warn!("Gemini response blocked by safety filters"),
+                "RECITATION" => warn!("Gemini response blocked due to recitation concerns"),
+                _ => {}
+            }
+        }
+
+        if let Some(content) = candidate.content {
+            let mut text = String::new();
+            for part in content.parts {
+                if let GeminiPart::Text { text: part_text } = part {
+                    text.push_str(&part_text);
+                }
+            }
+            if !text.trim().is_empty() {
+                return Ok(text);
+            }
+        }
+    }
+
+    Err(AdapterError::EmptyResponse)
+}
+
+fn parse_retry_delay(body: &str) -> Option<u64> {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(body) {
+        if let Some(details) = value
+            .get("error")
+            .and_then(|v| v.get("details"))
+            .and_then(|v| v.as_array())
+        {
+            for detail in details {
+                if let Some(delay) = detail
+                    .get("retryDelay")
+                    .or_else(|| detail.get("retry_delay"))
+                {
+                    if let Some(parsed) = parse_delay_value(delay) {
+                        return Some(parsed);
+                    }
+                }
+            }
+        }
+    }
+
+    static RETRY_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"retry[_ ]?delay[^0-9]*(\d+)").expect("valid regex for retry delay")
+    });
+
+    if let Some(caps) = RETRY_RE.captures(body) {
+        if let Some(matched) = caps.get(1) {
+            if let Ok(value) = matched.as_str().parse::<u64>() {
+                return Some(value);
+            }
+        }
+    }
+
+    None
+}
+
+fn parse_delay_value(value: &serde_json::Value) -> Option<u64> {
+    if let Some(number) = value.as_u64() {
+        return Some(number);
+    }
+
+    if let Some(text) = value.as_str() {
+        if let Ok(number) = text.trim_end_matches('s').parse::<u64>() {
+            return Some(number);
+        }
+    }
+
+    None
+}

--- a/crates/adapters/src/retry.rs
+++ b/crates/adapters/src/retry.rs
@@ -1,0 +1,54 @@
+use std::thread;
+use std::time::Duration;
+
+use log::warn;
+
+use crate::error::AdapterError;
+
+#[derive(Clone, Copy, Debug)]
+pub struct RetryConfig {
+    pub max_retries: usize,
+    pub sleep: Duration,
+}
+
+impl RetryConfig {
+    pub const fn new(max_retries: usize, sleep: Duration) -> Self {
+        Self { max_retries, sleep }
+    }
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            sleep: Duration::from_secs(2),
+        }
+    }
+}
+
+pub fn call_with_retry<F, T>(mut f: F, config: &RetryConfig) -> Result<T, AdapterError>
+where
+    F: FnMut() -> Result<T, AdapterError>,
+{
+    let mut last_error: Option<AdapterError> = None;
+
+    for attempt in 1..=config.max_retries {
+        match f() {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                let should_retry = attempt < config.max_retries;
+                warn!(
+                    "[call_with_retry] attempt {}/{} failed: {}",
+                    attempt, config.max_retries, err
+                );
+                if should_retry {
+                    thread::sleep(config.sleep);
+                }
+                last_error = Some(err);
+            }
+        }
+    }
+
+    let err = last_error.unwrap_or(AdapterError::EmptyResponse);
+    Err(AdapterError::retry_exhausted(config.max_retries, err))
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,4 +10,5 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 novel-core = { path = "../core" }
+novel-adapters = { path = "../adapters" }
 thiserror = { workspace = true }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,7 @@
 use clap::{Args, Parser, Subcommand};
+use novel_adapters::{
+    create_embedding_adapter, create_llm_adapter, AdapterError, EmbeddingModel, LanguageModel,
+};
 use novel_core::{ConfigStore, LogLevel, LogRecord, LogSink, StdoutLogSink};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -22,6 +25,7 @@ fn run() -> Result<(), CliError> {
 fn handle_config(cli: &Cli, command: ConfigCommand, sink: &dyn LogSink) -> Result<(), CliError> {
     match command {
         ConfigCommand::TestLlm(args) => run_test_llm(&cli.config, args, sink),
+        ConfigCommand::TestEmbedding(args) => run_test_embedding(&cli.config, args, sink),
     }
 }
 
@@ -41,13 +45,13 @@ fn run_test_llm(config_path: &Path, args: TestLlmArgs, sink: &dyn LogSink) -> Re
 
     let profile = store
         .config()
-        .llm_profiles
-        .get(&selected)
+        .get_llm_profile(&selected)
+        .cloned()
         .ok_or_else(|| CliError::UnknownInterface(selected.clone()))?;
 
     sink.log(LogRecord::new(
         LogLevel::Info,
-        format!("开始测试 LLM 配置（模拟）：{selected}"),
+        format!("开始测试 LLM 配置：{selected}"),
     ));
     sink.log(LogRecord::new(
         LogLevel::Debug,
@@ -56,12 +60,122 @@ fn run_test_llm(config_path: &Path, args: TestLlmArgs, sink: &dyn LogSink) -> Re
             profile.model_name, profile.interface_format, profile.base_url
         ),
     ));
+
+    let adapter = create_llm_adapter(store.config(), &selected)?;
     sink.log(LogRecord::new(
         LogLevel::Info,
-        "测试逻辑尚未实现，已完成占位执行。",
+        "发送测试提示词: Please reply 'OK'".to_string(),
     ));
 
+    match adapter.invoke("Please reply 'OK'") {
+        Ok(response) => {
+            if response.trim().is_empty() {
+                sink.log(LogRecord::new(
+                    LogLevel::Error,
+                    "❌ LLM配置测试失败：未获取到响应".to_string(),
+                ));
+                return Err(CliError::TestFailed(
+                    "LLM配置测试失败：未获取到响应".to_string(),
+                ));
+            }
+
+            sink.log(LogRecord::new(
+                LogLevel::Info,
+                "✅ LLM配置测试成功！".to_string(),
+            ));
+            sink.log(LogRecord::new(
+                LogLevel::Debug,
+                format!("测试回复: {response}"),
+            ));
+        }
+        Err(err) => {
+            sink.log(LogRecord::new(
+                LogLevel::Error,
+                format!("❌ LLM配置测试出错: {err}"),
+            ));
+            return Err(CliError::Adapter(err));
+        }
+    }
+
     store.touch_llm_interface(selected);
+    store.save()?;
+
+    Ok(())
+}
+
+fn run_test_embedding(
+    config_path: &Path,
+    args: TestEmbeddingArgs,
+    sink: &dyn LogSink,
+) -> Result<(), CliError> {
+    let mut store = ConfigStore::open(config_path.to_path_buf())?;
+    store.ensure_recent_defaults();
+
+    let selected = if let Some(interface) = args.interface {
+        interface
+    } else if let Some(name) = store.last_embedding_interface() {
+        name.to_string()
+    } else if let Some(name) = store.config().embedding_profiles.keys().next() {
+        name.clone()
+    } else {
+        return Err(CliError::MissingEmbeddingProfile);
+    };
+
+    let profile = store
+        .config()
+        .get_embedding_profile(&selected)
+        .cloned()
+        .ok_or_else(|| CliError::UnknownInterface(selected.clone()))?;
+
+    sink.log(LogRecord::new(
+        LogLevel::Info,
+        format!("开始测试 Embedding 配置：{selected}"),
+    ));
+    sink.log(LogRecord::new(
+        LogLevel::Debug,
+        format!(
+            "模型: {} | 接口模式: {} | Base URL: {}",
+            profile.model_name, profile.interface_format, profile.base_url
+        ),
+    ));
+
+    let adapter = create_embedding_adapter(store.config(), &selected)?;
+    sink.log(LogRecord::new(
+        LogLevel::Info,
+        "发送测试文本: 测试文本".to_string(),
+    ));
+
+    match adapter.embed_query("测试文本") {
+        Ok(vector) => {
+            if vector.is_empty() {
+                sink.log(LogRecord::new(
+                    LogLevel::Error,
+                    "❌ Embedding配置测试失败：未获取到向量".to_string(),
+                ));
+                return Err(CliError::TestFailed(
+                    "Embedding配置测试失败：未获取到向量".to_string(),
+                ));
+            }
+
+            sink.log(LogRecord::new(
+                LogLevel::Info,
+                "✅ Embedding配置测试成功！".to_string(),
+            ));
+            sink.log(LogRecord::new(
+                LogLevel::Debug,
+                format!("生成的向量维度: {}", vector.len()),
+            ));
+        }
+        Err(err) => {
+            sink.log(LogRecord::new(
+                LogLevel::Error,
+                format!("❌ Embedding配置测试出错: {err}"),
+            ));
+            return Err(CliError::Adapter(err));
+        }
+    }
+
+    store.touch_embedding_interface(selected);
     store.save()?;
 
     Ok(())
@@ -73,8 +187,14 @@ enum CliError {
     Config(#[from] novel_core::ConfigError),
     #[error("缺少可用的 LLM 配置，无法执行测试。")]
     MissingLlmProfile,
+    #[error("缺少可用的 Embedding 配置，无法执行测试。")]
+    MissingEmbeddingProfile,
     #[error("未找到名为 `{0}` 的接口配置")]
     UnknownInterface(String),
+    #[error("适配器调用失败: {0}")]
+    Adapter(#[from] AdapterError),
+    #[error("{0}")]
+    TestFailed(String),
 }
 
 #[derive(Parser)]
@@ -100,12 +220,21 @@ enum Command {
 
 #[derive(Subcommand)]
 enum ConfigCommand {
-    /// 测试当前 LLM 接口配置（占位实现）
+    /// 测试当前 LLM 接口配置
     TestLlm(TestLlmArgs),
+    /// 测试当前 Embedding 接口配置
+    TestEmbedding(TestEmbeddingArgs),
 }
 
 #[derive(Args)]
 struct TestLlmArgs {
+    /// 指定要测试的接口名称，默认为最近使用的接口
+    #[arg(long)]
+    interface: Option<String>,
+}
+
+#[derive(Args)]
+struct TestEmbeddingArgs {
     /// 指定要测试的接口名称，默认为最近使用的接口
     #[arg(long)]
     interface: Option<String>,


### PR DESCRIPTION
## Summary
- add adapter traits for language and embedding models backed by OpenAI-compatible, Azure, Gemini, and Ollama style endpoints
- implement base URL normalization plus shared retry helpers to mirror the Python behaviour
- wire the stage-one CLI config tests to the new adapters and add an embedding test command for parity with Python

## Testing
- cargo fmt
- cargo clippy --all --all-targets *(fails: unable to reach crates.io in the sandboxed environment)*
- cargo test --all *(fails: unable to reach crates.io in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9c7d19d0833386205add6f40b9b2