### PR TITLE
Add chapter generation pipeline in core crate

### DIFF
--- a/crates/adapters/src/llm.rs
+++ b/crates/adapters/src/llm.rs
@@ -244,7 +244,7 @@ impl OpenAiLikeAdapter {
 
 impl LanguageModel for OpenAiLikeAdapter {
     fn invoke(&self, prompt: &str) -> Result<String, LanguageModelError> {
-        call_with_retry(|| self.invoke_once(prompt), &self.retry).map_err(Into::into)
+        call_with_retry(|| self.invoke_once(prompt), &self.retry).map_err(LanguageModelError::new)
     }
 }
 
@@ -344,7 +344,7 @@ impl AzureOpenAiAdapter {
 
 impl LanguageModel for AzureOpenAiAdapter {
     fn invoke(&self, prompt: &str) -> Result<String, LanguageModelError> {
-        call_with_retry(|| self.invoke_once(prompt), &self.retry).map_err(Into::into)
+        call_with_retry(|| self.invoke_once(prompt), &self.retry).map_err(LanguageModelError::new)
     }
 }
 
@@ -451,7 +451,7 @@ impl AzureAiAdapter {
 
 impl LanguageModel for AzureAiAdapter {
     fn invoke(&self, prompt: &str) -> Result<String, LanguageModelError> {
-        call_with_retry(|| self.invoke_once(prompt), &self.retry).map_err(Into::into)
+        call_with_retry(|| self.invoke_once(prompt), &self.retry).map_err(LanguageModelError::new)
     }
 }
 
@@ -578,13 +578,13 @@ impl LanguageModel for GeminiAdapter {
                             continue;
                         }
                     }
-                    return Err(LanguageModelError::from(err));
+                    return Err(LanguageModelError::new(err));
                 }
             }
         }
 
         let err = last_error.unwrap_or(AdapterError::EmptyResponse);
-        Err(LanguageModelError::from(AdapterError::retry_exhausted(
+        Err(LanguageModelError::new(AdapterError::retry_exhausted(
             self.retry.max_retries,
             err,
         )))

--- a/crates/core/src/architecture/mod.rs
+++ b/crates/core/src/architecture/mod.rs
@@ -35,15 +35,6 @@ impl LanguageModelError {
     }
 }
 
-impl<E> From<E> for LanguageModelError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: E) -> Self {
-        Self::new(error)
-    }
-}
-
 impl fmt::Display for LanguageModelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.inner)
@@ -409,11 +400,11 @@ impl<'a> ArchitectureService<'a> {
             .format_with(
                 "core_seed",
                 [
-                    ("topic", request.topic.trim()),
-                    ("genre", request.genre.trim()),
+                    ("topic", request.topic.trim().to_string()),
+                    ("genre", request.genre.trim().to_string()),
                     ("number_of_chapters", request.number_of_chapters.to_string()),
                     ("word_number", request.word_number.to_string()),
-                    ("user_guidance", request.user_guidance.trim()),
+                    ("user_guidance", request.user_guidance.trim().to_string()),
                 ],
             )
             .map_err(|source| ArchitectureError::Prompt {
@@ -458,8 +449,11 @@ impl<'a> ArchitectureService<'a> {
             .format_with(
                 "character_dynamics",
                 [
-                    ("core_seed", state.core_seed().unwrap_or_default().trim()),
-                    ("user_guidance", request.user_guidance.trim()),
+                    (
+                        "core_seed",
+                        state.core_seed().unwrap_or_default().trim().to_string(),
+                    ),
+                    ("user_guidance", request.user_guidance.trim().to_string()),
                 ],
             )
             .map_err(|source| ArchitectureError::Prompt {
@@ -506,7 +500,11 @@ impl<'a> ArchitectureService<'a> {
                 "create_character_state",
                 [(
                     "character_dynamics",
-                    state.character_dynamics().unwrap_or_default().trim(),
+                    state
+                        .character_dynamics()
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string(),
                 )],
             )
             .map_err(|source| ArchitectureError::Prompt {
@@ -564,8 +562,11 @@ impl<'a> ArchitectureService<'a> {
             .format_with(
                 "world_building",
                 [
-                    ("core_seed", state.core_seed().unwrap_or_default().trim()),
-                    ("user_guidance", request.user_guidance.trim()),
+                    (
+                        "core_seed",
+                        state.core_seed().unwrap_or_default().trim().to_string(),
+                    ),
+                    ("user_guidance", request.user_guidance.trim().to_string()),
                 ],
             )
             .map_err(|source| ArchitectureError::Prompt {
@@ -610,16 +611,27 @@ impl<'a> ArchitectureService<'a> {
             .format_with(
                 "plot_architecture",
                 [
-                    ("core_seed", state.core_seed().unwrap_or_default().trim()),
+                    (
+                        "core_seed",
+                        state.core_seed().unwrap_or_default().trim().to_string(),
+                    ),
                     (
                         "character_dynamics",
-                        state.character_dynamics().unwrap_or_default().trim(),
+                        state
+                            .character_dynamics()
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string(),
                     ),
                     (
                         "world_building",
-                        state.world_building().unwrap_or_default().trim(),
+                        state
+                            .world_building()
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string(),
                     ),
-                    ("user_guidance", request.user_guidance.trim()),
+                    ("user_guidance", request.user_guidance.trim().to_string()),
                 ],
             )
             .map_err(|source| ArchitectureError::Prompt {

--- a/crates/core/src/chapter/keywords.rs
+++ b/crates/core/src/chapter/keywords.rs
@@ -1,0 +1,85 @@
+use crate::architecture::LanguageModel;
+use crate::blueprint::ChapterBlueprintEntry;
+use crate::prompts::{PromptArguments, PromptRegistry};
+
+use super::{ChapterError, ChapterPromptRequest, ChapterStage};
+
+pub fn generate_keyword_groups<M: LanguageModel>(
+    model: &M,
+    prompts: &PromptRegistry,
+    chapter: &ChapterBlueprintEntry,
+    request: &ChapterPromptRequest<'_>,
+    summary: &str,
+) -> Result<Vec<String>, ChapterError> {
+    let prompt = prompts
+        .format(
+            "knowledge_search",
+            &keyword_arguments(chapter, request, summary),
+        )
+        .map_err(|source| ChapterError::Prompt {
+            stage: ChapterStage::KeywordGeneration,
+            source,
+        })?;
+
+    let response = model
+        .invoke(&prompt)
+        .map_err(|source| ChapterError::Model {
+            stage: ChapterStage::KeywordGeneration,
+            source,
+        })?;
+
+    Ok(parse_keyword_groups(&response))
+}
+
+pub fn parse_keyword_groups(response: &str) -> Vec<String> {
+    response
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.contains('·') {
+                Some(trimmed.replace('·', " "))
+            } else {
+                None
+            }
+        })
+        .take(5)
+        .collect()
+}
+
+fn keyword_arguments(
+    chapter: &ChapterBlueprintEntry,
+    request: &ChapterPromptRequest<'_>,
+    summary: &str,
+) -> PromptArguments {
+    let mut args = PromptArguments::new();
+    args.insert("chapter_number".into(), request.novel_number.to_string());
+    args.insert("chapter_title".into(), chapter.chapter_title.clone());
+    args.insert(
+        "characters_involved".into(),
+        request.characters_involved.clone(),
+    );
+    args.insert("key_items".into(), request.key_items.clone());
+    args.insert("scene_location".into(), request.scene_location.clone());
+    args.insert("chapter_role".into(), chapter.chapter_role.clone());
+    args.insert("chapter_purpose".into(), chapter.chapter_purpose.clone());
+    args.insert("foreshadowing".into(), chapter.foreshadowing.clone());
+    args.insert("short_summary".into(), summary.to_string());
+    args.insert("user_guidance".into(), request.user_guidance.clone());
+    args.insert("time_constraint".into(), request.time_constraint.clone());
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_keyword_lines() {
+        let input = "科技公司·数据泄露\n无效行\n地下实验室·基因编辑·禁忌实验";
+        let groups = parse_keyword_groups(input);
+        assert_eq!(
+            groups,
+            vec!["科技公司 数据泄露", "地下实验室 基因编辑 禁忌实验"]
+        );
+    }
+}

--- a/crates/core/src/chapter/knowledge.rs
+++ b/crates/core/src/chapter/knowledge.rs
@@ -1,0 +1,178 @@
+use regex::Regex;
+use std::sync::OnceLock;
+
+use crate::architecture::LanguageModel;
+use crate::blueprint::ChapterBlueprintEntry;
+use crate::prompts::{PromptArguments, PromptRegistry};
+
+use super::{
+    truncate_to_owned, ChapterError, ChapterPromptRequest, ChapterStage, KNOWLEDGE_FALLBACK,
+    KNOWLEDGE_SNIPPET_MAX_CHARS,
+};
+
+pub fn apply_content_rules(contexts: &[String], chapter_number: u32) -> Vec<String> {
+    contexts
+        .iter()
+        .map(|text| annotate_context(text, chapter_number))
+        .collect()
+}
+
+pub fn filter_knowledge_contexts<M: LanguageModel>(
+    model: &M,
+    prompts: &PromptRegistry,
+    chapter: &ChapterBlueprintEntry,
+    request: &ChapterPromptRequest<'_>,
+    contexts: &[String],
+) -> Result<String, ChapterError> {
+    let processed = apply_knowledge_rules(contexts, request.novel_number);
+    let formatted = format_processed_contexts(&processed);
+
+    let mut args = PromptArguments::new();
+    args.insert("retrieved_texts".into(), formatted);
+    args.insert("chapter_info".into(), format_chapter_info(chapter, request));
+
+    let prompt = prompts
+        .format("knowledge_filter", &args)
+        .map_err(|source| ChapterError::Prompt {
+            stage: ChapterStage::KnowledgeFilter,
+            source,
+        })?;
+
+    let response = model
+        .invoke(&prompt)
+        .map_err(|source| ChapterError::Model {
+            stage: ChapterStage::KnowledgeFilter,
+            source,
+        })?;
+
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        Ok(KNOWLEDGE_FALLBACK.to_string())
+    } else {
+        Ok(trimmed.to_string())
+    }
+}
+
+fn annotate_context(text: &str, chapter_number: u32) -> String {
+    let base_text = text.trim();
+    if base_text.is_empty() {
+        return String::new();
+    }
+
+    if contains_chapter_reference(base_text) {
+        let recent = extract_recent_chapter(base_text);
+        let distance = chapter_number.saturating_sub(recent);
+
+        if distance <= 2 {
+            let preview = preview_with_limit(base_text, 120);
+            return format!("[SKIP] 跳过近章内容：{preview}");
+        } else if (3..=5).contains(&distance) {
+            return format!("[MOD40%] {base_text}（需修改≥40%）");
+        } else {
+            return format!("[OK] {base_text}（可引用核心）");
+        }
+    }
+
+    format!("[PRIOR] {base_text}（优先使用）")
+}
+
+fn apply_knowledge_rules(contexts: &[String], chapter_number: u32) -> Vec<String> {
+    contexts
+        .iter()
+        .map(|text| {
+            let trimmed = text.trim();
+            if trimmed.contains('第') && trimmed.contains('章') {
+                let recent = extract_recent_chapter(trimmed);
+                let distance = chapter_number.saturating_sub(recent);
+                if distance <= 3 {
+                    let preview = preview_with_limit(trimmed, 50);
+                    return format!("[历史章节限制] 跳过近期内容: {preview}");
+                }
+                format!("[历史参考] {trimmed} (需进行30%以上改写)")
+            } else {
+                format!("[外部知识] {trimmed}")
+            }
+        })
+        .collect()
+}
+
+fn format_processed_contexts(processed: &[String]) -> String {
+    if processed.is_empty() {
+        return "（无检索结果）".to_string();
+    }
+
+    processed
+        .iter()
+        .enumerate()
+        .map(|(idx, text)| {
+            let mut snippet = text.trim().to_string();
+            if snippet.chars().count() > KNOWLEDGE_SNIPPET_MAX_CHARS {
+                snippet = truncate_to_owned(&snippet, KNOWLEDGE_SNIPPET_MAX_CHARS);
+                snippet.push_str("...");
+            }
+            format!("[预处理结果{}]\n{}", idx + 1, snippet)
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn format_chapter_info(
+    chapter: &ChapterBlueprintEntry,
+    request: &ChapterPromptRequest<'_>,
+) -> String {
+    format!(
+        "当前章节定位：{}\n核心目标：{}\n关键要素：{} | {} | {}",
+        chapter.chapter_role,
+        chapter.chapter_purpose,
+        request.characters_involved,
+        request.key_items,
+        request.scene_location,
+    )
+}
+
+fn contains_chapter_reference(text: &str) -> bool {
+    static CHAPTER_RE: OnceLock<Regex> = OnceLock::new();
+    let regex = CHAPTER_RE.get_or_init(|| Regex::new(r"第\s*\d+\s*章|chapter_\d+").unwrap());
+    regex.is_match(text)
+}
+
+fn extract_recent_chapter(text: &str) -> u32 {
+    static DIGIT_RE: OnceLock<Regex> = OnceLock::new();
+    let regex = DIGIT_RE.get_or_init(|| Regex::new(r"\d+").unwrap());
+    regex
+        .find_iter(text)
+        .filter_map(|m| m.as_str().parse::<u32>().ok())
+        .max()
+        .unwrap_or(0)
+}
+
+fn preview_with_limit(text: &str, max_chars: usize) -> String {
+    if text.chars().count() > max_chars {
+        let mut snippet = truncate_to_owned(text, max_chars);
+        snippet.push_str("...");
+        snippet
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_rules_mark_recent_chapters() {
+        let contexts = vec!["chapter_10 发生冲突".to_string(), "全新设定".to_string()];
+        let annotated = apply_content_rules(&contexts, 11);
+        assert!(annotated[0].starts_with("[SKIP]"));
+        assert!(annotated[1].starts_with("[PRIOR]"));
+    }
+
+    #[test]
+    fn knowledge_rules_flag_recent_history() {
+        let contexts = vec!["第11章 冲突升级".to_string(), "外部知识".to_string()];
+        let processed = apply_knowledge_rules(&contexts, 12);
+        assert!(processed[0].contains("[历史章节限制]"));
+        assert!(processed[1].contains("[外部知识]"));
+    }
+}

--- a/crates/core/src/chapter/mod.rs
+++ b/crates/core/src/chapter/mod.rs
@@ -1,0 +1,477 @@
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::architecture::{
+    LanguageModel, LanguageModelError, ARCHITECTURE_FILE_NAME, CHARACTER_STATE_FILE_NAME,
+};
+use crate::blueprint::{ChapterBlueprint, ChapterBlueprintEntry};
+use crate::logging::{LogLevel, LogRecord, LogSink};
+use crate::prompts::{PromptError, PromptRegistry};
+
+mod keywords;
+mod knowledge;
+mod prompt;
+mod summary;
+
+use keywords::generate_keyword_groups;
+use knowledge::{apply_content_rules, filter_knowledge_contexts};
+use prompt::{render_first_chapter_prompt, render_next_chapter_prompt};
+use summary::{extract_summary, load_recent_chapters, summarize_recent_chapters};
+
+const GLOBAL_SUMMARY_FILE_NAME: &str = "global_summary.txt";
+const CHAPTERS_DIR_NAME: &str = "chapters";
+const MAX_HISTORY_CHAPTERS: usize = 3;
+const MAX_SUMMARY_SOURCE_CHARS: usize = 4_000;
+const MAX_SUMMARY_OUTPUT_CHARS: usize = 2_000;
+const PREVIOUS_EXCERPT_CHARS: usize = 800;
+const KNOWLEDGE_SNIPPET_MAX_CHARS: usize = 600;
+const KNOWLEDGE_FALLBACK: &str = "（知识库处理失败）";
+const KNOWLEDGE_EMPTY: &str = "（无相关知识库内容）";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChapterStage {
+    Summary,
+    KeywordGeneration,
+    KnowledgeFilter,
+    Prompt,
+    Draft,
+}
+
+impl ChapterStage {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Summary => "章节摘要",
+            Self::KeywordGeneration => "关键词检索",
+            Self::KnowledgeFilter => "知识过滤",
+            Self::Prompt => "提示词构建",
+            Self::Draft => "章节草稿生成",
+        }
+    }
+}
+
+impl fmt::Display for ChapterStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+#[derive(Debug)]
+pub struct KnowledgeBaseError {
+    inner: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl KnowledgeBaseError {
+    pub fn new<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            inner: Box::new(error),
+        }
+    }
+
+    pub fn into_inner(self) -> Box<dyn std::error::Error + Send + Sync> {
+        self.inner
+    }
+}
+
+impl fmt::Display for KnowledgeBaseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl std::error::Error for KnowledgeBaseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.inner.as_ref())
+    }
+}
+
+pub trait KnowledgeBase: Send + Sync {
+    fn count(&self) -> Result<Option<usize>, KnowledgeBaseError> {
+        Ok(None)
+    }
+
+    fn search(&self, query: &str, limit: usize) -> Result<Vec<String>, KnowledgeBaseError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChapterError {
+    #[error("未在章节蓝图中找到第{number}章信息")]
+    MissingChapter { number: u32 },
+    #[error("无法创建目录 `{path}`: {source}")]
+    CreateDir { path: PathBuf, source: io::Error },
+    #[error("读取文件 `{path}` 失败: {source}")]
+    ReadFile { path: PathBuf, source: io::Error },
+    #[error("写入文件 `{path}` 失败: {source}")]
+    WriteFile { path: PathBuf, source: io::Error },
+    #[error("渲染{stage}提示词失败: {source}")]
+    Prompt {
+        stage: ChapterStage,
+        #[source]
+        source: PromptError,
+    },
+    #[error("调用模型执行{stage}失败: {source}")]
+    Model {
+        stage: ChapterStage,
+        #[source]
+        source: LanguageModelError,
+    },
+    #[error("向量检索失败: {source}")]
+    KnowledgeBase {
+        #[source]
+        source: KnowledgeBaseError,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct ChapterPromptRequest<'a> {
+    pub output_dir: PathBuf,
+    pub blueprint: &'a ChapterBlueprint,
+    pub novel_number: u32,
+    pub word_number: u32,
+    pub user_guidance: String,
+    pub characters_involved: String,
+    pub key_items: String,
+    pub scene_location: String,
+    pub time_constraint: String,
+    pub embedding_retrieval_k: usize,
+    pub history_chapter_count: usize,
+}
+
+impl<'a> ChapterPromptRequest<'a> {
+    pub fn new(
+        output_dir: impl Into<PathBuf>,
+        blueprint: &'a ChapterBlueprint,
+        novel_number: u32,
+        word_number: u32,
+    ) -> Self {
+        Self {
+            output_dir: output_dir.into(),
+            blueprint,
+            novel_number,
+            word_number,
+            user_guidance: String::new(),
+            characters_involved: String::new(),
+            key_items: String::new(),
+            scene_location: String::new(),
+            time_constraint: String::new(),
+            embedding_retrieval_k: 2,
+            history_chapter_count: MAX_HISTORY_CHAPTERS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ChapterPrompt {
+    pub prompt_text: String,
+    pub summary: String,
+    pub keyword_groups: Vec<String>,
+    pub knowledge_contexts: Vec<String>,
+    pub filtered_context: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChapterDraft {
+    pub chapter_number: u32,
+    pub content: String,
+    pub prompt: String,
+    pub path: PathBuf,
+    pub summary: String,
+    pub filtered_context: String,
+}
+
+pub struct ChapterService<'a> {
+    prompts: &'a PromptRegistry,
+    sink: &'a dyn LogSink,
+}
+
+impl<'a> ChapterService<'a> {
+    pub fn new(prompts: &'a PromptRegistry, sink: &'a dyn LogSink) -> Self {
+        Self { prompts, sink }
+    }
+
+    pub fn build_chapter_prompt<M: LanguageModel, K: KnowledgeBase>(
+        &self,
+        model: &M,
+        knowledge_base: Option<&K>,
+        request: &ChapterPromptRequest<'_>,
+    ) -> Result<ChapterPrompt, ChapterError> {
+        let chapter = request.blueprint.chapter(request.novel_number).ok_or(
+            ChapterError::MissingChapter {
+                number: request.novel_number,
+            },
+        )?;
+
+        if request.novel_number == 1 {
+            return self.render_first_chapter_prompt(chapter, request);
+        }
+
+        let next_chapter = request
+            .novel_number
+            .checked_add(1)
+            .and_then(|next| request.blueprint.chapter(next));
+
+        let global_summary =
+            read_optional_file(&request.output_dir.join(GLOBAL_SUMMARY_FILE_NAME))?;
+        let character_state =
+            read_optional_file(&request.output_dir.join(CHARACTER_STATE_FILE_NAME))?;
+
+        let chapters_dir = request.output_dir.join(CHAPTERS_DIR_NAME);
+        let history_count = request.history_chapter_count.max(1);
+        let recent_chapters =
+            load_recent_chapters(&chapters_dir, request.novel_number, history_count);
+        let combined_text = recent_chapters.join("\n");
+        let combined_text_tail = tail_chars(&combined_text, MAX_SUMMARY_SOURCE_CHARS);
+
+        let mut summary_text = String::new();
+        if !combined_text_tail.trim().is_empty() {
+            self.log(LogLevel::Info, "生成章节摘要");
+            let summary_response = summarize_recent_chapters(
+                model,
+                self.prompts,
+                chapter,
+                next_chapter,
+                combined_text_tail,
+                request.novel_number,
+            )?;
+            summary_text = extract_summary(&summary_response);
+            if summary_text.is_empty() {
+                summary_text = truncate_to_owned(summary_response.trim(), MAX_SUMMARY_OUTPUT_CHARS);
+            } else {
+                summary_text = truncate_to_owned(&summary_text, MAX_SUMMARY_OUTPUT_CHARS);
+            }
+        }
+
+        let previous_excerpt = recent_chapters
+            .iter()
+            .rev()
+            .find(|text| !text.trim().is_empty())
+            .map(|text| tail_to_owned(text, PREVIOUS_EXCERPT_CHARS))
+            .unwrap_or_default();
+
+        self.log(LogLevel::Info, "生成知识检索关键词");
+        let keyword_groups =
+            generate_keyword_groups(model, self.prompts, chapter, request, &summary_text)?;
+
+        let mut knowledge_contexts = Vec::new();
+        if let Some(base) = knowledge_base {
+            let requested_k = request.embedding_retrieval_k.max(1);
+            let available_k = match base.count() {
+                Ok(option) => option
+                    .filter(|count| *count > 0)
+                    .map(|count| count.min(requested_k))
+                    .unwrap_or(requested_k),
+                Err(err) => {
+                    self.log(LogLevel::Error, format!("获取向量库容量失败: {err}"));
+                    requested_k
+                }
+            };
+
+            for group in &keyword_groups {
+                match base.search(group, available_k) {
+                    Ok(chunks) => {
+                        for chunk in chunks {
+                            if chunk.trim().is_empty() {
+                                continue;
+                            }
+                            let label = classify_keyword_group(group);
+                            knowledge_contexts.push(format!("{label} {chunk}"));
+                        }
+                    }
+                    Err(err) => {
+                        self.log(LogLevel::Error, format!("知识检索失败（{group}）: {err}"));
+                    }
+                }
+            }
+        }
+
+        let processed_contexts = apply_content_rules(&knowledge_contexts, request.novel_number);
+        let filtered_context = if processed_contexts.is_empty() {
+            KNOWLEDGE_EMPTY.to_string()
+        } else {
+            match filter_knowledge_contexts(
+                model,
+                self.prompts,
+                chapter,
+                request,
+                &processed_contexts,
+            ) {
+                Ok(text) => text,
+                Err(err) => {
+                    self.log(LogLevel::Error, format!("知识过滤失败: {err}"));
+                    KNOWLEDGE_FALLBACK.to_string()
+                }
+            }
+        };
+
+        let prompt_text = render_next_chapter_prompt(
+            self.prompts,
+            chapter,
+            next_chapter,
+            request,
+            &global_summary,
+            &previous_excerpt,
+            &character_state,
+            &summary_text,
+            &filtered_context,
+        )?;
+
+        Ok(ChapterPrompt {
+            prompt_text,
+            summary: summary_text,
+            keyword_groups,
+            knowledge_contexts: processed_contexts,
+            filtered_context,
+        })
+    }
+
+    pub fn generate_chapter_draft<M: LanguageModel, K: KnowledgeBase>(
+        &self,
+        model: &M,
+        knowledge_base: Option<&K>,
+        request: &ChapterPromptRequest<'_>,
+        custom_prompt: Option<&str>,
+    ) -> Result<ChapterDraft, ChapterError> {
+        let prompt_result = if let Some(text) = custom_prompt {
+            ChapterPrompt {
+                prompt_text: text.to_string(),
+                ..ChapterPrompt::default()
+            }
+        } else {
+            self.build_chapter_prompt(model, knowledge_base, request)?
+        };
+
+        self.log(
+            LogLevel::Info,
+            format!("调用模型生成第{}章草稿", request.novel_number),
+        );
+        let response =
+            model
+                .invoke(&prompt_result.prompt_text)
+                .map_err(|source| ChapterError::Model {
+                    stage: ChapterStage::Draft,
+                    source,
+                })?;
+
+        let chapters_dir = request.output_dir.join(CHAPTERS_DIR_NAME);
+        fs::create_dir_all(&chapters_dir).map_err(|source| ChapterError::CreateDir {
+            path: chapters_dir.clone(),
+            source,
+        })?;
+
+        let chapter_path = chapters_dir.join(format!("chapter_{}.txt", request.novel_number));
+        fs::write(&chapter_path, response.as_bytes()).map_err(|source| {
+            ChapterError::WriteFile {
+                path: chapter_path.clone(),
+                source,
+            }
+        })?;
+
+        Ok(ChapterDraft {
+            chapter_number: request.novel_number,
+            content: response,
+            prompt: prompt_result.prompt_text,
+            path: chapter_path,
+            summary: prompt_result.summary,
+            filtered_context: prompt_result.filtered_context,
+        })
+    }
+
+    fn render_first_chapter_prompt(
+        &self,
+        chapter: &ChapterBlueprintEntry,
+        request: &ChapterPromptRequest<'_>,
+    ) -> Result<ChapterPrompt, ChapterError> {
+        let architecture = read_optional_file(&request.output_dir.join(ARCHITECTURE_FILE_NAME))?;
+        let prompt_text =
+            render_first_chapter_prompt(self.prompts, chapter, request, &architecture)?;
+        Ok(ChapterPrompt {
+            prompt_text,
+            ..ChapterPrompt::default()
+        })
+    }
+
+    fn log(&self, level: LogLevel, message: impl Into<String>) {
+        self.sink.log(LogRecord::new(level, message.into()));
+    }
+}
+
+fn read_optional_file(path: &Path) -> Result<String, ChapterError> {
+    match fs::read_to_string(path) {
+        Ok(text) => Ok(text),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+        Err(source) => Err(ChapterError::ReadFile {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn tail_chars<'a>(text: &'a str, max_chars: usize) -> &'a str {
+    if max_chars == 0 {
+        return "";
+    }
+    let mut count = 0usize;
+    for (idx, _) in text.char_indices().rev() {
+        count += 1;
+        if count == max_chars {
+            return &text[idx..];
+        }
+    }
+    text
+}
+
+fn truncate_to_owned(text: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let mut end = text.len();
+    for (index, (idx, _)) in text.char_indices().enumerate() {
+        if index == max_chars {
+            end = idx;
+            break;
+        }
+    }
+    if end == text.len() {
+        text.to_string()
+    } else {
+        text[..end].to_string()
+    }
+}
+
+fn tail_to_owned(text: &str, max_chars: usize) -> String {
+    tail_chars(text, max_chars).to_string()
+}
+
+fn classify_keyword_group(group: &str) -> &'static str {
+    let normalized = group.to_lowercase();
+    if ["技法", "手法", "模板"].iter().any(|kw| group.contains(kw)) {
+        "[TECHNIQUE]"
+    } else if ["设定", "技术", "世界观"]
+        .iter()
+        .any(|kw| group.contains(kw))
+    {
+        "[SETTING]"
+    } else if normalized.contains("technique") {
+        "[TECHNIQUE]"
+    } else if normalized.contains("setting") {
+        "[SETTING]"
+    } else {
+        "[GENERAL]"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_keyword_groups() {
+        assert_eq!(classify_keyword_group("悬念技法"), "[TECHNIQUE]");
+        assert_eq!(classify_keyword_group("科技设定"), "[SETTING]");
+        assert_eq!(classify_keyword_group("普通 描写"), "[GENERAL]");
+    }
+}

--- a/crates/core/src/chapter/prompt.rs
+++ b/crates/core/src/chapter/prompt.rs
@@ -1,0 +1,141 @@
+use crate::blueprint::ChapterBlueprintEntry;
+use crate::prompts::{PromptArguments, PromptRegistry};
+
+use super::{ChapterError, ChapterPromptRequest, ChapterStage};
+
+pub fn render_first_chapter_prompt(
+    prompts: &PromptRegistry,
+    chapter: &ChapterBlueprintEntry,
+    request: &ChapterPromptRequest<'_>,
+    architecture: &str,
+) -> Result<String, ChapterError> {
+    let mut args = PromptArguments::new();
+    args.insert("novel_number".into(), request.novel_number.to_string());
+    args.insert("chapter_title".into(), chapter.chapter_title.clone());
+    args.insert("chapter_role".into(), chapter.chapter_role.clone());
+    args.insert("chapter_purpose".into(), chapter.chapter_purpose.clone());
+    args.insert("suspense_level".into(), chapter.suspense_level.clone());
+    args.insert("foreshadowing".into(), chapter.foreshadowing.clone());
+    args.insert("plot_twist_level".into(), chapter.plot_twist_level.clone());
+    args.insert("chapter_summary".into(), chapter.chapter_summary.clone());
+    args.insert("word_number".into(), request.word_number.to_string());
+    args.insert(
+        "characters_involved".into(),
+        request.characters_involved.clone(),
+    );
+    args.insert("key_items".into(), request.key_items.clone());
+    args.insert("scene_location".into(), request.scene_location.clone());
+    args.insert("time_constraint".into(), request.time_constraint.clone());
+    args.insert("user_guidance".into(), request.user_guidance.clone());
+    args.insert("novel_setting".into(), architecture.to_string());
+
+    prompts
+        .format("first_chapter_draft", &args)
+        .map_err(|source| ChapterError::Prompt {
+            stage: ChapterStage::Prompt,
+            source,
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn render_next_chapter_prompt(
+    prompts: &PromptRegistry,
+    chapter: &ChapterBlueprintEntry,
+    next: Option<&ChapterBlueprintEntry>,
+    request: &ChapterPromptRequest<'_>,
+    global_summary: &str,
+    previous_excerpt: &str,
+    character_state: &str,
+    short_summary: &str,
+    filtered_context: &str,
+) -> Result<String, ChapterError> {
+    let mut args = PromptArguments::new();
+    args.insert(
+        "user_guidance".into(),
+        user_guidance_value(&request.user_guidance),
+    );
+    args.insert("global_summary".into(), global_summary.to_string());
+    args.insert(
+        "previous_chapter_excerpt".into(),
+        previous_excerpt.to_string(),
+    );
+    args.insert("character_state".into(), character_state.to_string());
+    args.insert("short_summary".into(), short_summary.to_string());
+    args.insert("novel_number".into(), request.novel_number.to_string());
+    args.insert("chapter_title".into(), chapter.chapter_title.clone());
+    args.insert("chapter_role".into(), chapter.chapter_role.clone());
+    args.insert("chapter_purpose".into(), chapter.chapter_purpose.clone());
+    args.insert("suspense_level".into(), chapter.suspense_level.clone());
+    args.insert("foreshadowing".into(), chapter.foreshadowing.clone());
+    args.insert("plot_twist_level".into(), chapter.plot_twist_level.clone());
+    args.insert("chapter_summary".into(), chapter.chapter_summary.clone());
+    args.insert("word_number".into(), request.word_number.to_string());
+    args.insert(
+        "characters_involved".into(),
+        request.characters_involved.clone(),
+    );
+    args.insert("key_items".into(), request.key_items.clone());
+    args.insert("scene_location".into(), request.scene_location.clone());
+    args.insert("time_constraint".into(), request.time_constraint.clone());
+
+    let default_next_number = request.novel_number.saturating_add(1);
+    let (
+        next_title,
+        next_role,
+        next_purpose,
+        next_suspense,
+        next_foreshadowing,
+        next_twist,
+        next_summary,
+    ) = next
+        .map(|entry| {
+            (
+                entry.chapter_title.clone(),
+                entry.chapter_role.clone(),
+                entry.chapter_purpose.clone(),
+                entry.suspense_level.clone(),
+                entry.foreshadowing.clone(),
+                entry.plot_twist_level.clone(),
+                entry.chapter_summary.clone(),
+            )
+        })
+        .unwrap_or_else(|| {
+            (
+                "（未命名）".to_string(),
+                "过渡章节".to_string(),
+                "承上启下".to_string(),
+                "中等".to_string(),
+                "无特殊伏笔".to_string(),
+                "★☆☆☆☆".to_string(),
+                "衔接过渡内容".to_string(),
+            )
+        });
+
+    args.insert(
+        "next_chapter_number".into(),
+        default_next_number.to_string(),
+    );
+    args.insert("next_chapter_title".into(), next_title);
+    args.insert("next_chapter_role".into(), next_role);
+    args.insert("next_chapter_purpose".into(), next_purpose);
+    args.insert("next_chapter_suspense_level".into(), next_suspense);
+    args.insert("next_chapter_foreshadowing".into(), next_foreshadowing);
+    args.insert("next_chapter_plot_twist_level".into(), next_twist);
+    args.insert("next_chapter_summary".into(), next_summary);
+    args.insert("filtered_context".into(), filtered_context.to_string());
+
+    prompts
+        .format("next_chapter_draft", &args)
+        .map_err(|source| ChapterError::Prompt {
+            stage: ChapterStage::Prompt,
+            source,
+        })
+}
+
+fn user_guidance_value(value: &str) -> String {
+    if value.trim().is_empty() {
+        "无特殊指导".to_string()
+    } else {
+        value.to_string()
+    }
+}

--- a/crates/core/src/chapter/summary.rs
+++ b/crates/core/src/chapter/summary.rs
@@ -1,0 +1,150 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use crate::architecture::LanguageModel;
+use crate::blueprint::ChapterBlueprintEntry;
+use crate::prompts::{PromptArguments, PromptRegistry};
+
+use super::{ChapterError, ChapterStage};
+
+const SUMMARY_MARKERS: [&str; 4] = ["当前章节摘要:", "章节摘要:", "摘要:", "本章摘要:"];
+
+pub fn load_recent_chapters(dir: &Path, current: u32, count: usize) -> Vec<String> {
+    if current <= 1 || count == 0 {
+        return Vec::new();
+    }
+
+    let start = current.saturating_sub(count as u32).max(1);
+    let mut texts = Vec::new();
+    for chapter_number in start..current {
+        let path = dir.join(format!("chapter_{}.txt", chapter_number));
+        match fs::read_to_string(&path) {
+            Ok(text) => texts.push(text),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => texts.push(String::new()),
+            Err(_) => texts.push(String::new()),
+        }
+    }
+    texts
+}
+
+pub fn summarize_recent_chapters<M: LanguageModel>(
+    model: &M,
+    prompts: &PromptRegistry,
+    chapter: &ChapterBlueprintEntry,
+    next: Option<&ChapterBlueprintEntry>,
+    combined_text: &str,
+    chapter_number: u32,
+) -> Result<String, ChapterError> {
+    let prompt = prompts
+        .format(
+            "summarize_recent_chapters",
+            &summary_arguments(chapter, next, combined_text, chapter_number),
+        )
+        .map_err(|source| ChapterError::Prompt {
+            stage: ChapterStage::Summary,
+            source,
+        })?;
+
+    model.invoke(&prompt).map_err(|source| ChapterError::Model {
+        stage: ChapterStage::Summary,
+        source,
+    })
+}
+
+pub fn extract_summary(text: &str) -> String {
+    if text.trim().is_empty() {
+        return String::new();
+    }
+
+    for marker in SUMMARY_MARKERS {
+        if let Some(index) = text.find(marker) {
+            let (_, rest) = text.split_at(index + marker.len());
+            return rest.trim().to_string();
+        }
+    }
+
+    text.trim().to_string()
+}
+
+fn summary_arguments(
+    chapter: &ChapterBlueprintEntry,
+    next: Option<&ChapterBlueprintEntry>,
+    combined_text: &str,
+    chapter_number: u32,
+) -> PromptArguments {
+    let mut args = PromptArguments::new();
+    args.insert("combined_text".into(), combined_text.to_string());
+    args.insert("novel_number".into(), chapter_number.to_string());
+    args.insert("chapter_title".into(), chapter.chapter_title.clone());
+    args.insert("chapter_role".into(), chapter.chapter_role.clone());
+    args.insert("chapter_purpose".into(), chapter.chapter_purpose.clone());
+    args.insert("suspense_level".into(), chapter.suspense_level.clone());
+    args.insert("foreshadowing".into(), chapter.foreshadowing.clone());
+    args.insert("plot_twist_level".into(), chapter.plot_twist_level.clone());
+    args.insert("chapter_summary".into(), chapter.chapter_summary.clone());
+
+    let default_next_number = chapter_number.saturating_add(1);
+    let (
+        next_title,
+        next_role,
+        next_purpose,
+        next_summary,
+        next_suspense,
+        next_foreshadowing,
+        next_twist,
+    ) = next
+        .map(|entry| {
+            (
+                entry.chapter_title.clone(),
+                entry.chapter_role.clone(),
+                entry.chapter_purpose.clone(),
+                entry.chapter_summary.clone(),
+                entry.suspense_level.clone(),
+                entry.foreshadowing.clone(),
+                entry.plot_twist_level.clone(),
+            )
+        })
+        .unwrap_or_else(|| {
+            (
+                "（未命名）".to_string(),
+                "过渡章节".to_string(),
+                "承上启下".to_string(),
+                "衔接过渡内容".to_string(),
+                "中等".to_string(),
+                "无特殊伏笔".to_string(),
+                "★☆☆☆☆".to_string(),
+            )
+        });
+
+    args.insert(
+        "next_chapter_number".into(),
+        default_next_number.to_string(),
+    );
+    args.insert("next_chapter_title".into(), next_title);
+    args.insert("next_chapter_role".into(), next_role);
+    args.insert("next_chapter_purpose".into(), next_purpose);
+    args.insert("next_chapter_summary".into(), next_summary);
+    args.insert("next_chapter_suspense_level".into(), next_suspense);
+    args.insert("next_chapter_foreshadowing".into(), next_foreshadowing);
+    args.insert("next_chapter_plot_twist_level".into(), next_twist);
+
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_summary_by_marker() {
+        let response = "一些内容\n当前章节摘要: 这是摘要部分";
+        assert_eq!(extract_summary(response), "这是摘要部分");
+    }
+
+    #[test]
+    fn returns_trimmed_response_when_no_marker() {
+        let response = "纯文本摘要";
+        assert_eq!(extract_summary(response), "纯文本摘要");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod architecture;
 pub mod blueprint;
+pub mod chapter;
 pub mod config;
 pub mod logging;
 pub mod prompts;
@@ -11,6 +12,10 @@ pub use architecture::{
 pub use blueprint::{
     BlueprintError, ChapterBlueprint, ChapterBlueprintEntry, ChapterBlueprintRequest,
     ChapterBlueprintService, BLUEPRINT_FILE_NAME,
+};
+pub use chapter::{
+    ChapterDraft, ChapterError, ChapterPrompt, ChapterPromptRequest, ChapterService, ChapterStage,
+    KnowledgeBase, KnowledgeBaseError,
 };
 pub use config::{
     Config, ConfigError, ConfigStore, EmbeddingConfig, LlmConfig, NovelConfig, PromptConfig,


### PR DESCRIPTION
## Summary
- add a chapter service and supporting modules that orchestrate summary generation, keyword search, knowledge filtering, and prompt rendering
- update adapters, architecture, and blueprint helpers to integrate the new pipeline and ensure conversions/tests are thread-safe
- replace blueprint segmentation logic with a regex-free splitter and re-export the new chapter APIs from the core crate

## Testing
- cargo test -p novel-core

------
https://chatgpt.com/codex/tasks/task_e_68cfc6541f9c8333ab515d0c547d51ab