### PR TITLE
Add eframe-based desktop UI crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/adapters",
     "crates/gui",
     "crates/cli",
+    "crates/ui",
 ]
 resolver = "2"
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "novel-ui"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "novel_ui"
+path = "src/lib.rs"
+
+[[bin]]
+name = "novel-ui"
+path = "src/main.rs"
+
+[dependencies]
+eframe = { version = "0.27", default-features = false, features = ["glow"] }
+egui = "0.27"
+tokio = { version = "1.37", features = ["rt-multi-thread", "macros"] }
+novel-core = { path = "../core" }
+novel-adapters = { path = "../adapters" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+rfd = "0.14"

--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -1,0 +1,912 @@
+use std::path::{Path, PathBuf};
+
+use eframe::egui::{self, Color32};
+
+use crate::state::{ActiveTab, AppState, ChapterPreviewState, ConfirmationDialog, EditorTarget};
+use crate::tasks::{
+    BuildChapterPromptCommand, GenerateArchitectureCommand, GenerateBlueprintCommand,
+    GenerateChapterDraftCommand, ImportKnowledgeCommand, TaskCommand, TaskController, TaskEvent,
+    TaskKind, TestEmbeddingCommand, TestLlmCommand,
+};
+use novel_core::logging::{LogLevel, LogRecord};
+
+pub struct NovelGeneratorApp {
+    state: AppState,
+    tasks: TaskController,
+    status_message: Option<String>,
+}
+
+impl NovelGeneratorApp {
+    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        let default_path = PathBuf::from("config.json");
+        let mut status_message = None;
+        let state = match AppState::new(default_path.clone()) {
+            Ok(state) => state,
+            Err(err) => {
+                let mut message = format!("加载配置失败: {err}。已尝试重置为默认配置。");
+                let default = novel_core::config::Config::default();
+                if let Err(save_err) = default.to_path(&default_path) {
+                    message = format!("加载配置失败: {err}；写入默认配置失败: {save_err}");
+                }
+                status_message = Some(message);
+                AppState::new(default_path).expect("failed to initialize default configuration")
+            }
+        };
+
+        Self {
+            state,
+            tasks: TaskController::new(),
+            status_message,
+        }
+    }
+
+    fn handle_event(&mut self, event: TaskEvent) {
+        match event {
+            TaskEvent::Log(record) => self.state.push_log(record),
+            TaskEvent::TaskStarted(kind) => {
+                self.state.set_active_task(Some(kind));
+            }
+            TaskEvent::TaskFinished { kind, result } => {
+                self.state.set_active_task(None);
+                match result {
+                    Ok(()) => {
+                        self.state.push_log(LogRecord::new(
+                            LogLevel::Info,
+                            format!("{} 完成", kind.label()),
+                        ));
+                        if let Some(err) = self.handle_task_success(kind) {
+                            self.status_message = Some(err);
+                        } else {
+                            self.status_message = Some(format!("{} 完成", kind.label()));
+                        }
+                    }
+                    Err(err) => {
+                        self.state.push_log(LogRecord::new(
+                            LogLevel::Error,
+                            format!("{} 失败: {err}", kind.label()),
+                        ));
+                        self.status_message = Some(format!("任务失败: {err}"));
+                    }
+                }
+            }
+            TaskEvent::ChapterPromptReady {
+                number,
+                prompt,
+                summary,
+                filtered_context,
+            } => {
+                self.state.prompt_editor.set_text(prompt);
+                self.state.novel.last_prompt_summary = if summary.trim().is_empty() {
+                    None
+                } else {
+                    Some(summary)
+                };
+                self.state.novel.last_filtered_context = if filtered_context.trim().is_empty() {
+                    None
+                } else {
+                    Some(filtered_context)
+                };
+                self.state.push_log(LogRecord::new(
+                    LogLevel::Info,
+                    format!("章节 {number} 提示词已生成"),
+                ));
+                self.status_message = Some(format!("章节 {number} 提示词已生成"));
+            }
+            TaskEvent::ChapterDraftReady {
+                number,
+                path,
+                content,
+                prompt,
+                summary,
+                filtered_context,
+            } => {
+                self.state.prompt_editor.set_text(prompt);
+                self.state.chapter_editor.set_text(content);
+                self.state.novel.last_prompt_summary = if summary.trim().is_empty() {
+                    None
+                } else {
+                    Some(summary)
+                };
+                self.state.novel.last_filtered_context = if filtered_context.trim().is_empty() {
+                    None
+                } else {
+                    Some(filtered_context)
+                };
+                self.state.push_log(LogRecord::new(
+                    LogLevel::Info,
+                    format!("章节 {number} 草稿已生成：{}", path.display()),
+                ));
+                if let Err(err) = self.state.refresh_chapters() {
+                    self.status_message = Some(err);
+                } else {
+                    self.status_message = Some(format!("章节 {number} 草稿已生成"));
+                }
+            }
+            TaskEvent::KnowledgeImportFinished { inserted } => {
+                self.state.push_log(LogRecord::new(
+                    LogLevel::Info,
+                    format!("知识库导入完成，新增片段数量：{inserted}"),
+                ));
+                self.status_message = Some(format!("知识库导入完成，新增片段数量：{inserted}"));
+            }
+        }
+    }
+
+    fn handle_task_success(&mut self, kind: TaskKind) -> Option<String> {
+        let mut errors = Vec::new();
+        match kind {
+            TaskKind::GenerateArchitecture | TaskKind::GenerateBlueprint => {
+                if let Err(err) = self.state.refresh_role_library() {
+                    errors.push(err);
+                }
+                if let Err(err) = self.state.refresh_chapters() {
+                    errors.push(err);
+                }
+            }
+            TaskKind::GenerateChapterDraft | TaskKind::FinalizeChapter => {
+                if let Err(err) = self.state.refresh_chapters() {
+                    errors.push(err);
+                }
+            }
+            _ => {}
+        }
+
+        if errors.is_empty() {
+            None
+        } else {
+            Some(errors.join("；"))
+        }
+    }
+
+    fn save_config(&mut self) {
+        match self.state.persist_config() {
+            Ok(()) => self.status_message = Some("配置已保存".to_string()),
+            Err(err) => self.status_message = Some(format!("保存配置失败: {err}")),
+        }
+    }
+
+    fn reload_config(&mut self) {
+        let trimmed = self.state.config_path_input.trim();
+        if trimmed.is_empty() {
+            self.status_message = Some("请先输入配置文件路径".to_string());
+            return;
+        }
+        let path = PathBuf::from(trimmed);
+        match self.state.reload_from_path(path.clone()) {
+            Ok(()) => self.status_message = Some(format!("已重新加载配置：{}", path.display())),
+            Err(err) => self.status_message = Some(format!("加载配置失败: {err}")),
+        }
+    }
+
+    fn dispatch_command(&mut self, command: TaskCommand) {
+        if let Err(err) = self.state.persist_config() {
+            self.status_message = Some(format!("保存配置失败: {err}"));
+            return;
+        }
+        if let Err(err) = self.tasks.send(command) {
+            self.status_message = Some(format!("任务发送失败: {err}"));
+        }
+    }
+
+    fn show_confirmation_dialog(&mut self, ctx: &egui::Context) {
+        if let Some(dialog) = self.state.confirmation.clone() {
+            let mut decision = None;
+            egui::Window::new(dialog.title.clone())
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+                .show(ctx, |ui| {
+                    ui.label(dialog.message.as_str());
+                    ui.horizontal(|ui| {
+                        if ui.button("确认").clicked() {
+                            decision = Some(true);
+                        }
+                        if ui.button("取消").clicked() {
+                            decision = Some(false);
+                        }
+                    });
+                });
+            if let Some(confirm) = decision {
+                self.state.set_confirmation(None);
+                if confirm {
+                    self.dispatch_command(dialog.command);
+                }
+            }
+        }
+    }
+
+    fn enqueue_confirmation(&mut self, title: &str, message: String, command: TaskCommand) {
+        self.state.set_confirmation(Some(ConfirmationDialog {
+            title: title.to_string(),
+            message,
+            command,
+        }));
+    }
+    fn show_config_tab(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.label("配置文件路径");
+            let response = ui.text_edit_singleline(&mut self.state.config_path_input);
+            if response.changed() {
+                self.status_message = None;
+            }
+            if ui.button("浏览...").clicked() {
+                if let Some(path) = rfd::FileDialog::new().pick_file() {
+                    self.state.config_path_input = path.display().to_string();
+                }
+            }
+            if ui.button("重新加载").clicked() {
+                self.reload_config();
+            }
+            if ui.button("保存配置").clicked() {
+                self.save_config();
+            }
+        });
+
+        if let Some(status) = &self.status_message {
+            ui.colored_label(Color32::LIGHT_BLUE, status);
+        }
+
+        ui.separator();
+        self.show_llm_section(ui);
+        ui.separator();
+        self.show_embedding_section(ui);
+
+        ui.separator();
+        let busy = self.state.active_task.is_some();
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(!busy, egui::Button::new("测试 LLM 配置"))
+                .clicked()
+            {
+                let command = TaskCommand::TestLlm(TestLlmCommand {
+                    config_path: self.state.config_store().path().to_path_buf(),
+                    interface: self.state.config_panel.selected_llm.clone(),
+                });
+                self.enqueue_confirmation("确认", "立即测试 LLM 配置？".to_string(), command);
+            }
+            if ui
+                .add_enabled(!busy, egui::Button::new("测试 Embedding 配置"))
+                .clicked()
+            {
+                let command = TaskCommand::TestEmbedding(TestEmbeddingCommand {
+                    config_path: self.state.config_store().path().to_path_buf(),
+                    interface: self.state.config_panel.selected_embedding.clone(),
+                });
+                self.enqueue_confirmation("确认", "立即测试 Embedding 配置？".to_string(), command);
+            }
+        });
+    }
+
+    fn show_llm_section(&mut self, ui: &mut egui::Ui) {
+        ui.heading("LLM 配置");
+        let profiles = self.state.config_panel.llm_profiles.clone();
+        ui.horizontal(|ui| {
+            let selected = self
+                .state
+                .config_panel
+                .selected_llm
+                .clone()
+                .unwrap_or_else(|| "未选择".to_string());
+            egui::ComboBox::from_label("选择配置")
+                .selected_text(selected)
+                .show_ui(ui, |ui| {
+                    for name in profiles.iter() {
+                        let is_selected =
+                            self.state.config_panel.selected_llm.as_ref() == Some(name);
+                        if ui.selectable_label(is_selected, name).clicked() {
+                            self.state.select_llm_profile(Some(name.clone()));
+                        }
+                    }
+                });
+            if ui.button("新增配置").clicked() {
+                let name = self.state.config_panel.new_llm_name.clone();
+                match self.state.add_llm_profile(&name) {
+                    Ok(()) => self.status_message = Some("已新增 LLM 配置".to_string()),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui.button("删除配置").clicked() {
+                if let Some(name) = self.state.config_panel.selected_llm.clone() {
+                    match self.state.remove_llm_profile(&name) {
+                        Ok(()) => self.status_message = Some(format!("已删除配置 `{name}`")),
+                        Err(err) => self.status_message = Some(err),
+                    }
+                }
+            }
+        });
+        ui.horizontal(|ui| {
+            ui.label("新增名称");
+            ui.text_edit_singleline(&mut self.state.config_panel.new_llm_name);
+        });
+        ui.separator();
+        ui.horizontal(|ui| {
+            ui.label("API Key");
+            ui.text_edit_singleline(&mut self.state.config_panel.llm_form.api_key);
+        });
+        ui.horizontal(|ui| {
+            ui.label("Base URL");
+            ui.text_edit_singleline(&mut self.state.config_panel.llm_form.base_url);
+        });
+        ui.horizontal(|ui| {
+            ui.label("接口模式");
+            ui.text_edit_singleline(&mut self.state.config_panel.llm_form.interface_format);
+        });
+        ui.horizontal(|ui| {
+            ui.label("模型名称");
+            ui.text_edit_singleline(&mut self.state.config_panel.llm_form.model_name);
+        });
+        ui.horizontal(|ui| {
+            ui.label("温度");
+            ui.text_edit_singleline(&mut self.state.config_panel.llm_form.temperature);
+            ui.label("最大 Token");
+            ui.text_edit_singleline(&mut self.state.config_panel.llm_form.max_tokens);
+            ui.label("超时 (s)");
+            ui.text_edit_singleline(&mut self.state.config_panel.llm_form.timeout);
+        });
+    }
+
+    fn show_embedding_section(&mut self, ui: &mut egui::Ui) {
+        ui.heading("Embedding 配置");
+        let profiles = self.state.config_panel.embedding_profiles.clone();
+        ui.horizontal(|ui| {
+            let selected = self
+                .state
+                .config_panel
+                .selected_embedding
+                .clone()
+                .unwrap_or_else(|| "未选择".to_string());
+            egui::ComboBox::from_label("选择配置")
+                .selected_text(selected)
+                .show_ui(ui, |ui| {
+                    for name in profiles.iter() {
+                        let is_selected =
+                            self.state.config_panel.selected_embedding.as_ref() == Some(name);
+                        if ui.selectable_label(is_selected, name).clicked() {
+                            self.state.select_embedding_profile(Some(name.clone()));
+                        }
+                    }
+                });
+            if ui.button("新增配置").clicked() {
+                let name = self.state.config_panel.new_embedding_name.clone();
+                match self.state.add_embedding_profile(&name) {
+                    Ok(()) => self.status_message = Some("已新增 Embedding 配置".to_string()),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui.button("删除配置").clicked() {
+                if let Some(name) = self.state.config_panel.selected_embedding.clone() {
+                    match self.state.remove_embedding_profile(&name) {
+                        Ok(()) => self.status_message = Some(format!("已删除配置 `{name}`")),
+                        Err(err) => self.status_message = Some(err),
+                    }
+                }
+            }
+        });
+        ui.horizontal(|ui| {
+            ui.label("新增名称");
+            ui.text_edit_singleline(&mut self.state.config_panel.new_embedding_name);
+        });
+        ui.separator();
+        ui.horizontal(|ui| {
+            ui.label("API Key");
+            ui.text_edit_singleline(&mut self.state.config_panel.embedding_form.api_key);
+        });
+        ui.horizontal(|ui| {
+            ui.label("Base URL");
+            ui.text_edit_singleline(&mut self.state.config_panel.embedding_form.base_url);
+        });
+        ui.horizontal(|ui| {
+            ui.label("接口模式");
+            ui.text_edit_singleline(&mut self.state.config_panel.embedding_form.interface_format);
+        });
+        ui.horizontal(|ui| {
+            ui.label("模型名称");
+            ui.text_edit_singleline(&mut self.state.config_panel.embedding_form.model_name);
+        });
+        ui.horizontal(|ui| {
+            ui.label("检索条目");
+            ui.text_edit_singleline(&mut self.state.config_panel.embedding_form.retrieval_k);
+        });
+    }
+    fn show_novel_tab(&mut self, ui: &mut egui::Ui) {
+        ui.heading("小说基本信息");
+        egui::TextEdit::multiline(&mut self.state.novel.topic)
+            .desired_rows(3)
+            .show(ui);
+        ui.horizontal(|ui| {
+            ui.label("类型");
+            ui.text_edit_singleline(&mut self.state.novel.genre);
+            ui.label("章节数");
+            ui.text_edit_singleline(&mut self.state.novel.num_chapters);
+            ui.label("章节字数");
+            ui.text_edit_singleline(&mut self.state.novel.word_number);
+        });
+        ui.horizontal(|ui| {
+            ui.label("输出目录");
+            ui.text_edit_singleline(&mut self.state.novel.output_dir);
+            if ui.button("浏览...").clicked() {
+                if let Some(path) = rfd::FileDialog::new().pick_folder() {
+                    self.state.novel.output_dir = path.display().to_string();
+                }
+            }
+        });
+        if ui.button("保存小说参数").clicked() {
+            self.save_config();
+        }
+
+        ui.separator();
+        ui.heading("章节生成参数");
+        ui.horizontal(|ui| {
+            ui.label("章节编号");
+            ui.text_edit_singleline(&mut self.state.novel.chapter_number);
+            ui.label("角色参与");
+            ui.text_edit_singleline(&mut self.state.novel.characters_involved);
+        });
+        ui.horizontal(|ui| {
+            ui.label("关键物品");
+            ui.text_edit_singleline(&mut self.state.novel.key_items);
+            ui.label("场景位置");
+            ui.text_edit_singleline(&mut self.state.novel.scene_location);
+        });
+        ui.horizontal(|ui| {
+            ui.label("时间限制");
+            ui.text_edit_singleline(&mut self.state.novel.time_constraint);
+        });
+        ui.horizontal(|ui| {
+            ui.label("向量检索 K");
+            ui.text_edit_singleline(&mut self.state.novel.embedding_retrieval_k);
+            ui.label("历史章节数");
+            ui.text_edit_singleline(&mut self.state.novel.history_chapter_count);
+        });
+        ui.label("内容指导");
+        egui::TextEdit::multiline(&mut self.state.novel.user_guidance)
+            .desired_rows(4)
+            .show(ui);
+
+        ui.separator();
+        let busy = self.state.active_task.is_some();
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(!busy, egui::Button::new("生成小说架构"))
+                .clicked()
+            {
+                match self.state.make_generate_architecture_command() {
+                    Ok(cmd) => self.enqueue_confirmation(
+                        "确认",
+                        "确定要生成小说架构吗？".to_string(),
+                        TaskCommand::GenerateArchitecture(cmd),
+                    ),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui
+                .add_enabled(!busy, egui::Button::new("生成章节蓝图"))
+                .clicked()
+            {
+                match self.state.make_generate_blueprint_command() {
+                    Ok(cmd) => self.enqueue_confirmation(
+                        "确认",
+                        "确定要生成章节蓝图吗？".to_string(),
+                        TaskCommand::GenerateBlueprint(cmd),
+                    ),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui
+                .add_enabled(!busy, egui::Button::new("构建章节提示词"))
+                .clicked()
+            {
+                match self.state.make_build_prompt_command() {
+                    Ok(cmd) => self.enqueue_confirmation(
+                        "确认",
+                        "构建提示词将调用模型，是否继续？".to_string(),
+                        TaskCommand::BuildChapterPrompt(cmd),
+                    ),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+        });
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(!busy, egui::Button::new("生成章节草稿"))
+                .clicked()
+            {
+                match self.state.make_generate_draft_command() {
+                    Ok(cmd) => self.enqueue_confirmation(
+                        "确认",
+                        "生成草稿将写入章节文件，是否继续？".to_string(),
+                        TaskCommand::GenerateChapterDraft(cmd),
+                    ),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui
+                .add_enabled(!busy, egui::Button::new("章节定稿"))
+                .clicked()
+            {
+                match self.state.make_finalize_command() {
+                    Ok(cmd) => self.enqueue_confirmation(
+                        "确认",
+                        "定稿将更新摘要与角色状态，是否继续？".to_string(),
+                        TaskCommand::FinalizeChapter(cmd),
+                    ),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+        });
+
+        ui.separator();
+        ui.heading("知识库导入");
+        ui.horizontal(|ui| {
+            ui.label("向量库 URL");
+            ui.text_edit_singleline(&mut self.state.novel.vector_url);
+        });
+        ui.horizontal(|ui| {
+            ui.label("集合名称");
+            ui.text_edit_singleline(&mut self.state.novel.vector_collection);
+            ui.label("API Key");
+            ui.text_edit_singleline(&mut self.state.novel.vector_api_key);
+        });
+        ui.horizontal(|ui| {
+            ui.label("待导入文件");
+            ui.text_edit_singleline(&mut self.state.novel.knowledge_file);
+            if ui.button("选择文件").clicked() {
+                if let Some(path) = rfd::FileDialog::new().pick_file() {
+                    self.state.novel.knowledge_file = path.display().to_string();
+                }
+            }
+        });
+        if ui
+            .add_enabled(!busy, egui::Button::new("导入知识库"))
+            .clicked()
+        {
+            match self.state.make_import_command() {
+                Ok(cmd) => self.enqueue_confirmation(
+                    "确认",
+                    "确定要导入知识库文件吗？".to_string(),
+                    TaskCommand::ImportKnowledge(cmd),
+                ),
+                Err(err) => self.status_message = Some(err),
+            }
+        }
+
+        ui.separator();
+        ui.heading("提示词编辑器");
+        let response = self.state.prompt_editor.ui(ui, "prompt_editor", 12);
+        self.state
+            .update_editor_focus(EditorTarget::Prompt, response.has_focus());
+        ui.horizontal(|ui| {
+            ui.label(format!("字数：{}", self.state.prompt_editor.char_count()));
+            ui.label(format!("词数：{}", self.state.prompt_editor.word_count()));
+        });
+        if let Some(summary) = &self.state.novel.last_prompt_summary {
+            ui.collapsing("最近生成的摘要", |ui| {
+                ui.label(summary);
+            });
+        }
+        if let Some(context) = &self.state.novel.last_filtered_context {
+            ui.collapsing("过滤后的知识上下文", |ui| {
+                ui.label(context);
+            });
+        }
+    }
+    fn show_role_library_tab(&mut self, ui: &mut egui::Ui) {
+        let output_dir = match self.state.novel.output_dir_path() {
+            Some(path) => path,
+            None => {
+                ui.label("请先配置小说输出目录。");
+                return;
+            }
+        };
+
+        if self.state.role_library.categories.is_empty() {
+            let _ = self.state.refresh_role_library();
+        }
+
+        if ui.button("刷新角色库").clicked() {
+            if let Err(err) = self.state.refresh_role_library() {
+                self.status_message = Some(err);
+            }
+        }
+        if let Some(status) = &self.state.role_library.status {
+            ui.colored_label(Color32::LIGHT_BLUE, status);
+        }
+
+        ui.columns(2, |columns| {
+            self.render_role_sidebar(&output_dir, &mut columns[0]);
+            self.render_role_editor(&output_dir, &mut columns[1]);
+        });
+    }
+
+    fn render_role_sidebar(&mut self, root: &Path, ui: &mut egui::Ui) {
+        ui.heading("分类");
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            let categories = self.state.role_library.categories.clone();
+            for category in categories {
+                let selected =
+                    self.state.role_library.selected_category.as_ref() == Some(&category);
+                if ui.selectable_label(selected, category.clone()).clicked() {
+                    if let Err(err) = self
+                        .state
+                        .role_library
+                        .select_category(category.clone(), root)
+                    {
+                        self.status_message = Some(err.to_string());
+                    }
+                }
+            }
+        });
+
+        ui.separator();
+        ui.heading("角色");
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            let roles = self.state.role_library.roles.clone();
+            for role in roles {
+                let selected = self.state.role_library.selected_role.as_ref() == Some(&role.name);
+                if ui.selectable_label(selected, role.name.clone()).clicked() {
+                    if let Err(err) = self.state.role_library.select_role(role.name.clone(), root) {
+                        self.status_message = Some(err.to_string());
+                    }
+                }
+            }
+        });
+
+        ui.horizontal(|ui| {
+            ui.label("新建分类");
+            ui.text_edit_singleline(&mut self.state.role_library.new_category_name);
+            if ui.button("创建").clicked() {
+                let name = self.state.role_library.new_category_name.clone();
+                match self.state.role_library.create_category(root, &name) {
+                    Ok(()) => self.status_message = Some("已创建分类".to_string()),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+        });
+    }
+    fn render_role_editor(&mut self, root: &Path, ui: &mut egui::Ui) {
+        ui.heading("角色详情");
+        ui.horizontal(|ui| {
+            ui.label("角色名称");
+            ui.text_edit_singleline(&mut self.state.role_library.role_name_input);
+            ui.label("目标分类");
+            let categories = self.state.role_library.categories.clone();
+            egui::ComboBox::from_id_source("role_move_target")
+                .selected_text(self.state.role_library.move_target.clone())
+                .show_ui(ui, |ui| {
+                    for category in categories {
+                        if ui
+                            .selectable_label(
+                                self.state.role_library.move_target == category,
+                                category.clone(),
+                            )
+                            .clicked()
+                        {
+                            self.state.role_library.move_target = category;
+                        }
+                    }
+                });
+        });
+
+        let response = self.state.role_library.editor.ui(ui, "role_editor", 16);
+        self.state
+            .update_editor_focus(EditorTarget::Role, response.has_focus());
+        ui.horizontal(|ui| {
+            ui.label(format!(
+                "字数：{}",
+                self.state.role_library.editor.char_count()
+            ));
+        });
+
+        ui.horizontal(|ui| {
+            if ui.button("保存").clicked() {
+                match self.state.role_library.save(root) {
+                    Ok(()) => self.status_message = Some("角色已保存".to_string()),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui.button("删除").clicked() {
+                match self.state.role_library.delete_role(root) {
+                    Ok(()) => self.status_message = Some("角色已删除".to_string()),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui.button("新建角色").clicked() {
+                let name = self.state.role_library.role_name_input.clone();
+                match self.state.role_library.create_role(root, &name) {
+                    Ok(()) => self.status_message = Some("已创建新角色".to_string()),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            if ui.button("导入文本").clicked() {
+                if let Some(files) = rfd::FileDialog::new().pick_files() {
+                    let paths: Vec<PathBuf> = files.into_iter().collect();
+                    match self.state.role_library.import_files(root, &paths) {
+                        Ok(()) => self.status_message = Some("已导入角色".to_string()),
+                        Err(err) => self.status_message = Some(err),
+                    }
+                }
+            }
+        });
+        ui.horizontal(|ui| {
+            if ui.button("插入到提示词").clicked() {
+                let text = self.state.role_library.editor.text().to_string();
+                self.state.queue_insert(EditorTarget::Prompt, text);
+            }
+            if ui.button("插入到章节").clicked() {
+                let text = self.state.role_library.editor.text().to_string();
+                self.state.queue_insert(EditorTarget::Chapter, text);
+            }
+        });
+    }
+    fn show_chapters_tab(&mut self, ui: &mut egui::Ui) {
+        let output_dir = match self.state.novel.output_dir_path() {
+            Some(path) => path,
+            None => {
+                ui.label("请先配置小说输出目录。");
+                return;
+            }
+        };
+
+        ui.horizontal(|ui| {
+            if ui.button("刷新").clicked() {
+                if let Err(err) = self.state.refresh_chapters() {
+                    self.status_message = Some(err);
+                }
+            }
+            if ui.button("上一章").clicked() {
+                if let Some(prev) = previous_chapter(&self.state.chapters) {
+                    if let Err(err) = self.state.load_chapter(prev) {
+                        self.status_message = Some(err);
+                    }
+                }
+            }
+            if ui.button("下一章").clicked() {
+                if let Some(next) = next_chapter(&self.state.chapters) {
+                    if let Err(err) = self.state.load_chapter(next) {
+                        self.status_message = Some(err);
+                    }
+                }
+            }
+            if ui.button("保存章节").clicked() {
+                match self.state.save_current_chapter() {
+                    Ok(()) => self.status_message = Some("章节已保存".to_string()),
+                    Err(err) => self.status_message = Some(err),
+                }
+            }
+            let chapters = self
+                .state
+                .chapters
+                .chapters
+                .iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>();
+            let selected_label = self
+                .state
+                .chapters
+                .selected
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "未选择".to_string());
+            egui::ComboBox::from_label("章节")
+                .selected_text(selected_label)
+                .show_ui(ui, |ui| {
+                    for label in chapters {
+                        if let Ok(value) = label.parse::<u32>() {
+                            if ui
+                                .selectable_label(
+                                    self.state.chapters.selected == Some(value),
+                                    label,
+                                )
+                                .clicked()
+                            {
+                                if let Err(err) = self.state.load_chapter(value) {
+                                    self.status_message = Some(err);
+                                }
+                            }
+                        }
+                    }
+                });
+        });
+
+        let response = self.state.chapter_editor.ui(ui, "chapter_editor", 18);
+        self.state
+            .update_editor_focus(EditorTarget::Chapter, response.has_focus());
+        ui.horizontal(|ui| {
+            ui.label(format!("字数：{}", self.state.chapter_editor.char_count()));
+            ui.label(format!("词数：{}", self.state.chapter_editor.word_count()));
+        });
+    }
+    fn show_logs_tab(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            if ui.button("清空日志").clicked() {
+                self.state.clear_logs();
+            }
+            if let Some(task) = self.state.active_task {
+                ui.label(format!("当前任务：{}", task.label()));
+            }
+        });
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            for record in self.state.logs.iter() {
+                let color = match record.level {
+                    LogLevel::Error => Color32::RED,
+                    LogLevel::Warn => Color32::YELLOW,
+                    LogLevel::Info => Color32::LIGHT_GREEN,
+                    LogLevel::Debug => Color32::LIGHT_BLUE,
+                    LogLevel::Trace => Color32::GRAY,
+                };
+                ui.colored_label(color, format!("[{}] {}", record.level, record.message));
+            }
+        });
+    }
+    fn apply_pending_inserts(&mut self) {
+        while let Some((target, text)) = self.state.next_insert() {
+            match target {
+                EditorTarget::Prompt => self.state.prompt_editor.insert_text(&text),
+                EditorTarget::Chapter => self.state.chapter_editor.insert_text(&text),
+                EditorTarget::Role => self.state.role_library.editor.insert_text(&text),
+            }
+        }
+    }
+}
+impl eframe::App for NovelGeneratorApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        while let Some(event) = self.tasks.try_recv() {
+            self.handle_event(event);
+        }
+
+        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.heading("AI Novel Generator");
+                if let Some(status) = &self.status_message {
+                    ui.colored_label(Color32::LIGHT_BLUE, status);
+                }
+                if let Some(editor) = self.state.focused_editor {
+                    ui.label(format!("当前编辑区：{}", editor.label()));
+                }
+            });
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                for tab in ActiveTab::ALL {
+                    let selected = self.state.active_tab == tab;
+                    if ui.selectable_label(selected, tab.label()).clicked() {
+                        self.state.active_tab = tab;
+                    }
+                }
+            });
+            ui.separator();
+            match self.state.active_tab {
+                ActiveTab::Config => self.show_config_tab(ui),
+                ActiveTab::Novel => self.show_novel_tab(ui),
+                ActiveTab::RoleLibrary => self.show_role_library_tab(ui),
+                ActiveTab::Chapters => self.show_chapters_tab(ui),
+                ActiveTab::Logs => self.show_logs_tab(ui),
+            }
+        });
+
+        self.apply_pending_inserts();
+        self.show_confirmation_dialog(ctx);
+    }
+}
+
+fn previous_chapter(state: &ChapterPreviewState) -> Option<u32> {
+    let selected = state.selected?;
+    let position = state
+        .chapters
+        .iter()
+        .position(|chapter| *chapter == selected)?;
+    if position > 0 {
+        state.chapters.get(position - 1).copied()
+    } else {
+        None
+    }
+}
+
+fn next_chapter(state: &ChapterPreviewState) -> Option<u32> {
+    let selected = state.selected?;
+    let position = state
+        .chapters
+        .iter()
+        .position(|chapter| *chapter == selected)?;
+    state.chapters.get(position + 1).copied()
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,0 +1,22 @@
+pub mod app;
+pub mod state;
+pub mod tasks;
+pub mod text_editor;
+
+pub use app::NovelGeneratorApp;
+pub use tasks::{TaskCommand, TaskController, TaskEvent, TaskKind};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn run() -> eframe::Result<()> {
+    use eframe::NativeOptions;
+
+    let options = NativeOptions {
+        centered: true,
+        ..Default::default()
+    };
+    eframe::run_native(
+        "AI Novel Generator",
+        options,
+        Box::new(|cc| Box::new(NovelGeneratorApp::new(cc))),
+    )
+}

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -1,0 +1,3 @@
+fn main() -> eframe::Result<()> {
+    novel_ui::run()
+}

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -1,0 +1,1168 @@
+use crate::tasks::{
+    BuildChapterPromptCommand, FinalizeChapterCommand, GenerateArchitectureCommand,
+    GenerateBlueprintCommand, GenerateChapterDraftCommand, ImportKnowledgeCommand, TaskCommand,
+    TaskKind,
+};
+use crate::text_editor::TextEditorState;
+use novel_core::config::{
+    Config, ConfigError, ConfigStore, EmbeddingConfig, LlmConfig, NovelConfig,
+};
+use novel_core::logging::{LogLevel, LogRecord};
+use std::collections::VecDeque;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+const ROLE_LIBRARY_DIR: &str = "角色库";
+const ROLE_LIBRARY_ALL: &str = "全部";
+const CHAPTERS_DIR: &str = "chapters";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ActiveTab {
+    Config,
+    Novel,
+    RoleLibrary,
+    Chapters,
+    Logs,
+}
+
+impl ActiveTab {
+    pub const ALL: [Self; 5] = [
+        ActiveTab::Config,
+        ActiveTab::Novel,
+        ActiveTab::RoleLibrary,
+        ActiveTab::Chapters,
+        ActiveTab::Logs,
+    ];
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            ActiveTab::Config => "配置面板",
+            ActiveTab::Novel => "小说参数",
+            ActiveTab::RoleLibrary => "角色库",
+            ActiveTab::Chapters => "章节预览",
+            ActiveTab::Logs => "日志窗口",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EditorTarget {
+    Prompt,
+    Chapter,
+    Role,
+}
+
+impl EditorTarget {
+    pub fn label(self) -> &'static str {
+        match self {
+            EditorTarget::Prompt => "提示词编辑器",
+            EditorTarget::Chapter => "章节编辑器",
+            EditorTarget::Role => "角色编辑器",
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ValidationError {
+    #[error("{0}")]
+    Message(String),
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+}
+
+impl ValidationError {
+    pub fn message(msg: impl Into<String>) -> Self {
+        Self::Message(msg.into())
+    }
+}
+
+#[derive(Clone)]
+pub struct ConfirmationDialog {
+    pub title: String,
+    pub message: String,
+    pub command: TaskCommand,
+}
+
+pub struct AppState {
+    config_store: ConfigStore,
+    pub config_path_input: String,
+    pub config_panel: ConfigPanelState,
+    pub novel: NovelParametersState,
+    pub role_library: RoleLibraryState,
+    pub chapters: ChapterPreviewState,
+    pub logs: LogPanelState,
+    pub prompt_editor: TextEditorState,
+    pub chapter_editor: TextEditorState,
+    pub active_tab: ActiveTab,
+    pub focused_editor: Option<EditorTarget>,
+    pending_insert: VecDeque<(EditorTarget, String)>,
+    pub confirmation: Option<ConfirmationDialog>,
+    pub active_task: Option<TaskKind>,
+}
+
+impl AppState {
+    pub fn new(config_path: PathBuf) -> Result<Self, ConfigError> {
+        let mut store = ConfigStore::open(config_path)?;
+        store.ensure_recent_defaults();
+        let config_panel = ConfigPanelState::from_store(&store);
+        let novel = NovelParametersState::from_config(store.config());
+        let role_library = RoleLibraryState::new();
+        let chapters = ChapterPreviewState::new();
+        let logs = LogPanelState::new();
+        let prompt_editor = TextEditorState::new();
+        let chapter_editor = TextEditorState::new();
+        let config_path_input = store.path().to_string_lossy().to_string();
+
+        Ok(Self {
+            config_store: store,
+            config_path_input,
+            config_panel,
+            novel,
+            role_library,
+            chapters,
+            logs,
+            prompt_editor,
+            chapter_editor,
+            active_tab: ActiveTab::Config,
+            focused_editor: None,
+            pending_insert: VecDeque::new(),
+            confirmation: None,
+            active_task: None,
+        })
+    }
+
+    pub fn config_path(&self) -> &Path {
+        self.config_store.path()
+    }
+
+    pub fn reload_from_path(&mut self, path: PathBuf) -> Result<(), ConfigError> {
+        let mut store = ConfigStore::open(path.clone())?;
+        store.ensure_recent_defaults();
+        self.config_store = store;
+        self.config_panel = ConfigPanelState::from_store(&self.config_store);
+        self.novel = NovelParametersState::from_config(self.config_store.config());
+        self.config_path_input = path.to_string_lossy().to_string();
+        Ok(())
+    }
+
+    pub fn refresh_from_store(&mut self) {
+        self.config_panel = ConfigPanelState::from_store(&self.config_store);
+        self.novel = NovelParametersState::from_config(self.config_store.config());
+    }
+
+    pub fn sync_form_state(&mut self) -> Result<(), ValidationError> {
+        self.config_panel
+            .apply_to_store(self.config_store.config_mut())?;
+        self.novel.apply_to_store(self.config_store.config_mut())?;
+        Ok(())
+    }
+
+    pub fn persist_config(&mut self) -> Result<(), ValidationError> {
+        self.sync_form_state()?;
+        self.config_store.save()?;
+        self.refresh_from_store();
+        Ok(())
+    }
+
+    pub fn config_store(&self) -> &ConfigStore {
+        &self.config_store
+    }
+
+    pub fn config_store_mut(&mut self) -> &mut ConfigStore {
+        &mut self.config_store
+    }
+
+    pub fn select_llm_profile(&mut self, name: Option<String>) {
+        let store = self.config_store();
+        self.config_panel.select_llm(name, store);
+    }
+
+    pub fn select_embedding_profile(&mut self, name: Option<String>) {
+        let store = self.config_store();
+        self.config_panel.select_embedding(name, store);
+    }
+
+    pub fn queue_insert(&mut self, target: EditorTarget, text: String) {
+        if text.trim().is_empty() {
+            return;
+        }
+        self.pending_insert.push_back((target, text));
+    }
+
+    pub fn next_insert(&mut self) -> Option<(EditorTarget, String)> {
+        self.pending_insert.pop_front()
+    }
+
+    pub fn update_editor_focus(&mut self, target: EditorTarget, has_focus: bool) {
+        if has_focus {
+            self.focused_editor = Some(target);
+        } else if self.focused_editor == Some(target) {
+            self.focused_editor = None;
+        }
+    }
+
+    pub fn set_confirmation(&mut self, dialog: Option<ConfirmationDialog>) {
+        self.confirmation = dialog;
+    }
+
+    pub fn take_confirmation(&mut self) -> Option<ConfirmationDialog> {
+        self.confirmation.take()
+    }
+
+    pub fn set_active_task(&mut self, task: Option<TaskKind>) {
+        self.active_task = task;
+    }
+
+    pub fn push_log(&mut self, record: LogRecord) {
+        self.logs.push(record);
+    }
+
+    pub fn clear_logs(&mut self) {
+        self.logs.clear();
+    }
+
+    pub fn refresh_role_library(&mut self) -> Result<(), String> {
+        let path = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        self.role_library
+            .refresh(&path)
+            .map_err(|err| format!("角色库读取失败: {err}"))
+    }
+
+    pub fn refresh_chapters(&mut self) -> Result<(), String> {
+        let path = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        self.chapters
+            .refresh(&path)
+            .map_err(|err| format!("章节读取失败: {err}"))
+    }
+
+    pub fn load_chapter(&mut self, number: u32) -> Result<(), String> {
+        let path = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        let text = self
+            .chapters
+            .load(number, &path)
+            .map_err(|err| format!("加载章节失败: {err}"))?;
+        self.chapter_editor.set_text(text);
+        self.chapters.selected = Some(number);
+        Ok(())
+    }
+
+    pub fn save_current_chapter(&mut self) -> Result<(), String> {
+        let number = self
+            .chapters
+            .selected
+            .ok_or_else(|| "尚未选择章节".to_string())?;
+        let path = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        self.chapters
+            .save(number, &path, self.chapter_editor.text())
+            .map_err(|err| format!("保存章节失败: {err}"))
+    }
+
+    pub fn add_llm_profile(&mut self, name: &str) -> Result<(), String> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err("请输入新的 LLM 配置名称".to_string());
+        }
+        if self
+            .config_store
+            .config()
+            .llm_profiles
+            .contains_key(trimmed)
+        {
+            return Err(format!("LLM 配置 `{trimmed}` 已存在"));
+        }
+        self.config_store
+            .config_mut()
+            .llm_profiles
+            .insert(trimmed.to_string(), LlmConfig::default());
+        self.config_panel = ConfigPanelState::from_store(&self.config_store);
+        self.config_panel
+            .select_llm(Some(trimmed.to_string()), &self.config_store);
+        Ok(())
+    }
+
+    pub fn remove_llm_profile(&mut self, name: &str) -> Result<(), String> {
+        if self
+            .config_store
+            .config_mut()
+            .llm_profiles
+            .remove(name)
+            .is_none()
+        {
+            return Err(format!("未找到 LLM 配置 `{name}`"));
+        }
+        self.config_panel = ConfigPanelState::from_store(&self.config_store);
+        Ok(())
+    }
+
+    pub fn add_embedding_profile(&mut self, name: &str) -> Result<(), String> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err("请输入新的 Embedding 配置名称".to_string());
+        }
+        if self
+            .config_store
+            .config()
+            .embedding_profiles
+            .contains_key(trimmed)
+        {
+            return Err(format!("Embedding 配置 `{trimmed}` 已存在"));
+        }
+        self.config_store
+            .config_mut()
+            .embedding_profiles
+            .insert(trimmed.to_string(), EmbeddingConfig::default());
+        self.config_panel = ConfigPanelState::from_store(&self.config_store);
+        self.config_panel
+            .select_embedding(Some(trimmed.to_string()), &self.config_store);
+        Ok(())
+    }
+
+    pub fn remove_embedding_profile(&mut self, name: &str) -> Result<(), String> {
+        if self
+            .config_store
+            .config_mut()
+            .embedding_profiles
+            .remove(name)
+            .is_none()
+        {
+            return Err(format!("未找到 Embedding 配置 `{name}`"));
+        }
+        self.config_panel = ConfigPanelState::from_store(&self.config_store);
+        Ok(())
+    }
+
+    pub fn make_generate_architecture_command(
+        &self,
+    ) -> Result<GenerateArchitectureCommand, String> {
+        let output_dir = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        let number_of_chapters = self.novel.parse_num_chapters()?;
+        let word_number = self.novel.parse_word_number()?;
+        let topic = self.novel.topic.clone();
+        let genre = self.novel.genre.clone();
+        let user_guidance = self.novel.user_guidance.clone();
+        Ok(GenerateArchitectureCommand {
+            config_path: self.config_store.path().to_path_buf(),
+            output_dir,
+            topic,
+            genre,
+            number_of_chapters,
+            word_number,
+            user_guidance,
+            llm_interface: self.config_panel.selected_llm.clone(),
+        })
+    }
+
+    pub fn make_generate_blueprint_command(&self) -> Result<GenerateBlueprintCommand, String> {
+        let output_dir = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        let number_of_chapters = self.novel.parse_num_chapters()?;
+        let max_tokens = self.config_panel.llm_form.parse_max_tokens()?;
+        let user_guidance = self.novel.user_guidance.clone();
+        Ok(GenerateBlueprintCommand {
+            config_path: self.config_store.path().to_path_buf(),
+            output_dir,
+            number_of_chapters,
+            max_tokens,
+            user_guidance,
+            llm_interface: self.config_panel.selected_llm.clone(),
+        })
+    }
+
+    pub fn make_build_prompt_command(&self) -> Result<BuildChapterPromptCommand, String> {
+        let output_dir = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        let chapter_number = self.novel.parse_chapter_number()?;
+        let word_number = self.novel.parse_word_number()?;
+        let embedding_k = self.novel.parse_embedding_k()?;
+        let history = self.novel.parse_history_count()?;
+        Ok(BuildChapterPromptCommand {
+            config_path: self.config_store.path().to_path_buf(),
+            output_dir,
+            chapter_number,
+            word_number,
+            user_guidance: self.novel.user_guidance.clone(),
+            characters_involved: self.novel.characters_involved.clone(),
+            key_items: self.novel.key_items.clone(),
+            scene_location: self.novel.scene_location.clone(),
+            time_constraint: self.novel.time_constraint.clone(),
+            embedding_retrieval_k: embedding_k,
+            history_chapter_count: history,
+            llm_interface: self.config_panel.selected_llm.clone(),
+            embedding_interface: self.config_panel.selected_embedding.clone(),
+        })
+    }
+
+    pub fn make_generate_draft_command(&self) -> Result<GenerateChapterDraftCommand, String> {
+        let base = self.make_build_prompt_command()?;
+        let custom_prompt = if self.prompt_editor.text().trim().is_empty() {
+            None
+        } else {
+            Some(self.prompt_editor.text().to_string())
+        };
+        Ok(GenerateChapterDraftCommand {
+            base,
+            custom_prompt,
+        })
+    }
+
+    pub fn make_finalize_command(&self) -> Result<FinalizeChapterCommand, String> {
+        let output_dir = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        let chapter_number = self.novel.parse_chapter_number()?;
+        Ok(FinalizeChapterCommand {
+            config_path: self.config_store.path().to_path_buf(),
+            output_dir,
+            chapter_number,
+            llm_interface: self.config_panel.selected_llm.clone(),
+            embedding_interface: self.config_panel.selected_embedding.clone(),
+        })
+    }
+
+    pub fn make_import_command(&self) -> Result<ImportKnowledgeCommand, String> {
+        let output_dir = self
+            .novel
+            .output_dir_path()
+            .ok_or_else(|| "请先配置小说保存目录".to_string())?;
+        let file = self
+            .novel
+            .knowledge_file_path()
+            .ok_or_else(|| "请选择要导入的知识库文件".to_string())?;
+        Ok(ImportKnowledgeCommand {
+            config_path: self.config_store.path().to_path_buf(),
+            output_dir,
+            file,
+            embedding_interface: self.config_panel.selected_embedding.clone(),
+            vector_url: self.novel.vector_url.clone(),
+            collection: self.novel.vector_collection.clone(),
+            api_key: if self.novel.vector_api_key.trim().is_empty() {
+                None
+            } else {
+                Some(self.novel.vector_api_key.trim().to_string())
+            },
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConfigPanelState {
+    pub selected_llm: Option<String>,
+    pub selected_embedding: Option<String>,
+    pub llm_profiles: Vec<String>,
+    pub embedding_profiles: Vec<String>,
+    pub llm_form: LlmProfileForm,
+    pub embedding_form: EmbeddingProfileForm,
+    pub new_llm_name: String,
+    pub new_embedding_name: String,
+    pub status: Option<String>,
+}
+
+impl ConfigPanelState {
+    pub fn from_store(store: &ConfigStore) -> Self {
+        let llm_profiles = store
+            .config()
+            .llm_profiles
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let embedding_profiles = store
+            .config()
+            .embedding_profiles
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let selected_llm = store.last_llm_interface().map(|s| s.to_string());
+        let selected_embedding = store.last_embedding_interface().map(|s| s.to_string());
+        let llm_form = selected_llm
+            .as_ref()
+            .and_then(|name| store.config().llm_profiles.get(name))
+            .map(LlmProfileForm::from_config)
+            .unwrap_or_default();
+        let embedding_form = selected_embedding
+            .as_ref()
+            .and_then(|name| store.config().embedding_profiles.get(name))
+            .map(EmbeddingProfileForm::from_config)
+            .unwrap_or_default();
+        Self {
+            selected_llm,
+            selected_embedding,
+            llm_profiles,
+            embedding_profiles,
+            llm_form,
+            embedding_form,
+            new_llm_name: String::new(),
+            new_embedding_name: String::new(),
+            status: None,
+        }
+    }
+
+    pub fn select_llm(&mut self, name: Option<String>, store: &ConfigStore) {
+        self.selected_llm = name.clone();
+        if let Some(name) = name {
+            if let Some(profile) = store.config().llm_profiles.get(&name) {
+                self.llm_form = LlmProfileForm::from_config(profile);
+            }
+        }
+    }
+
+    pub fn select_embedding(&mut self, name: Option<String>, store: &ConfigStore) {
+        self.selected_embedding = name.clone();
+        if let Some(name) = name {
+            if let Some(profile) = store.config().embedding_profiles.get(&name) {
+                self.embedding_form = EmbeddingProfileForm::from_config(profile);
+            }
+        }
+    }
+
+    pub fn apply_to_store(&self, config: &mut Config) -> Result<(), ValidationError> {
+        if let Some(name) = &self.selected_llm {
+            let parsed = self.llm_form.to_config()?;
+            config.upsert_llm_profile(name.clone(), parsed);
+        }
+        if let Some(name) = &self.selected_embedding {
+            let parsed = self.embedding_form.to_config()?;
+            config.upsert_embedding_profile(name.clone(), parsed);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LlmProfileForm {
+    pub api_key: String,
+    pub base_url: String,
+    pub interface_format: String,
+    pub model_name: String,
+    pub temperature: String,
+    pub max_tokens: String,
+    pub timeout: String,
+}
+
+impl LlmProfileForm {
+    pub fn from_config(config: &LlmConfig) -> Self {
+        Self {
+            api_key: config.api_key.clone(),
+            base_url: config.base_url.clone(),
+            interface_format: config.interface_format.clone(),
+            model_name: config.model_name.clone(),
+            temperature: format!("{:.2}", config.temperature),
+            max_tokens: config.max_tokens.to_string(),
+            timeout: config.timeout.to_string(),
+        }
+    }
+
+    pub fn to_config(&self) -> Result<LlmConfig, ValidationError> {
+        let temperature: f32 = self
+            .temperature
+            .parse()
+            .map_err(|_| ValidationError::message("温度参数需要为数字"))?;
+        let max_tokens: u32 = self
+            .max_tokens
+            .parse()
+            .map_err(|_| ValidationError::message("最大 Token 数需要为整数"))?;
+        let timeout: u64 = self
+            .timeout
+            .parse()
+            .map_err(|_| ValidationError::message("请求超时需要为整数"))?;
+        Ok(LlmConfig {
+            api_key: self.api_key.trim().to_string(),
+            base_url: self.base_url.trim().to_string(),
+            interface_format: self.interface_format.trim().to_string(),
+            model_name: self.model_name.trim().to_string(),
+            temperature,
+            max_tokens,
+            timeout,
+        })
+    }
+
+    pub fn parse_max_tokens(&self) -> Result<u32, String> {
+        self.max_tokens
+            .parse()
+            .map_err(|_| "最大 Token 数需要为整数".to_string())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct EmbeddingProfileForm {
+    pub api_key: String,
+    pub base_url: String,
+    pub interface_format: String,
+    pub model_name: String,
+    pub retrieval_k: String,
+}
+
+impl EmbeddingProfileForm {
+    pub fn from_config(config: &EmbeddingConfig) -> Self {
+        Self {
+            api_key: config.api_key.clone(),
+            base_url: config.base_url.clone(),
+            interface_format: config.interface_format.clone(),
+            model_name: config.model_name.clone(),
+            retrieval_k: config.retrieval_k.to_string(),
+        }
+    }
+
+    pub fn to_config(&self) -> Result<EmbeddingConfig, ValidationError> {
+        let retrieval_k: u32 = self
+            .retrieval_k
+            .parse()
+            .map_err(|_| ValidationError::message("检索条目数量需要为整数"))?;
+        Ok(EmbeddingConfig {
+            api_key: self.api_key.trim().to_string(),
+            base_url: self.base_url.trim().to_string(),
+            interface_format: self.interface_format.trim().to_string(),
+            model_name: self.model_name.trim().to_string(),
+            retrieval_k,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NovelParametersState {
+    pub topic: String,
+    pub genre: String,
+    pub num_chapters: String,
+    pub word_number: String,
+    pub output_dir: String,
+    pub chapter_number: String,
+    pub user_guidance: String,
+    pub characters_involved: String,
+    pub key_items: String,
+    pub scene_location: String,
+    pub time_constraint: String,
+    pub embedding_retrieval_k: String,
+    pub history_chapter_count: String,
+    pub vector_url: String,
+    pub vector_collection: String,
+    pub vector_api_key: String,
+    pub knowledge_file: String,
+    pub last_prompt_summary: Option<String>,
+    pub last_filtered_context: Option<String>,
+}
+
+impl NovelParametersState {
+    pub fn from_config(config: &Config) -> Self {
+        let novel = &config.novel;
+        Self {
+            topic: novel.topic.clone(),
+            genre: novel.genre.clone(),
+            num_chapters: if novel.num_chapters == 0 {
+                String::from("10")
+            } else {
+                novel.num_chapters.to_string()
+            },
+            word_number: if novel.word_number == 0 {
+                String::from("3000")
+            } else {
+                novel.word_number.to_string()
+            },
+            output_dir: novel.filepath.clone(),
+            chapter_number: String::from("1"),
+            user_guidance: String::new(),
+            characters_involved: String::new(),
+            key_items: String::new(),
+            scene_location: String::new(),
+            time_constraint: String::new(),
+            embedding_retrieval_k: config
+                .embedding_profiles
+                .values()
+                .next()
+                .map(|p| p.retrieval_k.to_string())
+                .unwrap_or_else(|| "4".to_string()),
+            history_chapter_count: String::from("3"),
+            vector_url: String::from("http://localhost:6333"),
+            vector_collection: String::from("novel_collection"),
+            vector_api_key: String::new(),
+            knowledge_file: String::new(),
+            last_prompt_summary: None,
+            last_filtered_context: None,
+        }
+    }
+
+    pub fn apply_to_store(&self, config: &mut Config) -> Result<(), ValidationError> {
+        let num_chapters = self.parse_num_chapters()?;
+        let word_number = self.parse_word_number()?;
+        config.novel = NovelConfig {
+            topic: self.topic.trim().to_string(),
+            genre: self.genre.trim().to_string(),
+            num_chapters,
+            word_number,
+            filepath: self.output_dir.trim().to_string(),
+        };
+        Ok(())
+    }
+
+    pub fn output_dir_path(&self) -> Option<PathBuf> {
+        let trimmed = self.output_dir.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(trimmed))
+        }
+    }
+
+    pub fn knowledge_file_path(&self) -> Option<PathBuf> {
+        let trimmed = self.knowledge_file.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(trimmed))
+        }
+    }
+
+    pub fn parse_num_chapters(&self) -> Result<u32, String> {
+        self.num_chapters
+            .trim()
+            .parse()
+            .map_err(|_| "章节数量需要为整数".to_string())
+    }
+
+    pub fn parse_word_number(&self) -> Result<u32, String> {
+        self.word_number
+            .trim()
+            .parse()
+            .map_err(|_| "章节字数需要为整数".to_string())
+    }
+
+    pub fn parse_chapter_number(&self) -> Result<u32, String> {
+        self.chapter_number
+            .trim()
+            .parse()
+            .map_err(|_| "章节编号需要为整数".to_string())
+    }
+
+    pub fn parse_embedding_k(&self) -> Result<usize, String> {
+        self.embedding_retrieval_k
+            .trim()
+            .parse()
+            .map_err(|_| "向量检索数量需要为整数".to_string())
+    }
+
+    pub fn parse_history_count(&self) -> Result<usize, String> {
+        self.history_chapter_count
+            .trim()
+            .parse()
+            .map_err(|_| "历史章节数量需要为整数".to_string())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RoleLibraryState {
+    pub categories: Vec<String>,
+    pub selected_category: Option<String>,
+    pub roles: Vec<RoleEntry>,
+    pub selected_role: Option<String>,
+    pub role_name_input: String,
+    pub new_category_name: String,
+    pub move_target: String,
+    pub editor: TextEditorState,
+    pub status: Option<String>,
+}
+
+impl RoleLibraryState {
+    pub fn new() -> Self {
+        Self {
+            categories: Vec::new(),
+            selected_category: None,
+            roles: Vec::new(),
+            selected_role: None,
+            role_name_input: String::new(),
+            new_category_name: String::new(),
+            move_target: ROLE_LIBRARY_ALL.to_string(),
+            editor: TextEditorState::new(),
+            status: None,
+        }
+    }
+
+    pub fn refresh(&mut self, root: &Path) -> io::Result<()> {
+        ensure_role_library(root)?;
+        self.categories = collect_categories(root);
+        if self.selected_category.is_none() {
+            self.selected_category = Some(ROLE_LIBRARY_ALL.to_string());
+        }
+        if !self
+            .categories
+            .iter()
+            .any(|c| Some(c) == self.selected_category.as_ref())
+        {
+            self.selected_category = Some(ROLE_LIBRARY_ALL.to_string());
+        }
+        self.update_roles(root)?;
+        Ok(())
+    }
+
+    fn update_roles(&mut self, root: &Path) -> io::Result<()> {
+        let category = self
+            .selected_category
+            .clone()
+            .unwrap_or_else(|| ROLE_LIBRARY_ALL.to_string());
+        self.roles = collect_roles(root, &category)?;
+        if let Some(selected) = &self.selected_role {
+            if !self.roles.iter().any(|role| &role.name == selected) {
+                self.selected_role = None;
+            }
+        }
+        if self.selected_role.is_none() {
+            self.selected_role = self.roles.first().map(|role| role.name.clone());
+        }
+        if let Some(selected) = self.selected_role.clone() {
+            self.role_name_input = selected.clone();
+            if let Some(entry) = self.current_entry() {
+                match fs::read_to_string(&entry.path) {
+                    Ok(text) => self.editor.set_text(text),
+                    Err(err) => {
+                        self.editor.clear();
+                        self.status = Some(format!("读取角色文件失败: {err}"));
+                    }
+                }
+            }
+        } else {
+            self.editor.clear();
+            self.role_name_input.clear();
+        }
+        self.move_target = self
+            .selected_category
+            .clone()
+            .unwrap_or_else(|| ROLE_LIBRARY_ALL.to_string());
+        Ok(())
+    }
+
+    pub fn select_category(&mut self, category: String, root: &Path) -> io::Result<()> {
+        self.selected_category = Some(category);
+        self.update_roles(root)
+    }
+
+    pub fn select_role(&mut self, role: String, root: &Path) -> io::Result<()> {
+        self.selected_role = Some(role.clone());
+        self.role_name_input = role;
+        self.update_roles(root)
+    }
+
+    pub fn save(&mut self, root: &Path) -> Result<(), String> {
+        if self.role_name_input.trim().is_empty() {
+            return Err("请填写角色名称".to_string());
+        }
+        let entry = self
+            .current_entry()
+            .cloned()
+            .ok_or_else(|| "请先选择角色".to_string())?;
+        let new_name = self.role_name_input.trim();
+        let target_category = if self.move_target.trim().is_empty() {
+            entry.category.clone()
+        } else {
+            self.move_target.trim().to_string()
+        };
+        ensure_category(root, &target_category)
+            .map_err(|err| format!("创建分类目录失败: {err}"))?;
+        let new_path = role_path(root, &target_category, new_name);
+        if entry.path != new_path {
+            if new_path.exists() {
+                return Err("目标分类中已存在同名角色".to_string());
+            }
+            fs::rename(&entry.path, &new_path).map_err(|err| format!("移动角色文件失败: {err}"))?;
+        }
+        fs::write(&new_path, self.editor.text())
+            .map_err(|err| format!("写入角色文件失败: {err}"))?;
+        self.status = Some("角色已保存".to_string());
+        self.selected_category = Some(target_category.clone());
+        self.selected_role = Some(new_name.to_string());
+        self.update_roles(root)
+            .map_err(|err| format!("刷新角色列表失败: {err}"))?;
+        Ok(())
+    }
+
+    pub fn create_category(&mut self, root: &Path, name: &str) -> Result<(), String> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err("请输入分类名称".to_string());
+        }
+        ensure_category(root, trimmed).map_err(|err| err.to_string())?;
+        self.refresh(root)
+            .map_err(|err| format!("刷新角色列表失败: {err}"))?;
+        self.status = Some(format!("已创建分类 `{trimmed}`"));
+        Ok(())
+    }
+
+    pub fn create_role(&mut self, root: &Path, name: &str) -> Result<(), String> {
+        let category = self
+            .selected_category
+            .clone()
+            .unwrap_or_else(|| ROLE_LIBRARY_ALL.to_string());
+        let target = if category == ROLE_LIBRARY_ALL {
+            ROLE_LIBRARY_ALL.to_string()
+        } else {
+            category
+        };
+        ensure_category(root, &target).map_err(|err| format!("创建分类目录失败: {err}"))?;
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err("请输入角色名称".to_string());
+        }
+        let path = role_path(root, &target, trimmed);
+        if path.exists() {
+            return Err("同名角色已存在".to_string());
+        }
+        fs::write(&path, "").map_err(|err| format!("创建角色文件失败: {err}"))?;
+        self.status = Some("已创建空白角色".to_string());
+        self.selected_category = Some(target);
+        self.selected_role = Some(trimmed.to_string());
+        self.update_roles(root)
+            .map_err(|err| format!("刷新角色列表失败: {err}"))?;
+        Ok(())
+    }
+
+    pub fn delete_role(&mut self, root: &Path) -> Result<(), String> {
+        let entry = self
+            .current_entry()
+            .cloned()
+            .ok_or_else(|| "请先选择角色".to_string())?;
+        fs::remove_file(&entry.path).map_err(|err| format!("删除角色文件失败: {err}"))?;
+        self.status = Some("角色已删除".to_string());
+        self.selected_role = None;
+        self.update_roles(root)
+            .map_err(|err| format!("刷新角色列表失败: {err}"))?;
+        Ok(())
+    }
+
+    pub fn import_files(&mut self, root: &Path, files: &[PathBuf]) -> Result<(), String> {
+        if files.is_empty() {
+            return Ok(());
+        }
+        let category = self
+            .selected_category
+            .clone()
+            .unwrap_or_else(|| ROLE_LIBRARY_ALL.to_string());
+        let target = if category == ROLE_LIBRARY_ALL {
+            ROLE_LIBRARY_ALL.to_string()
+        } else {
+            category
+        };
+        ensure_category(root, &target).map_err(|err| format!("创建分类目录失败: {err}"))?;
+        let mut imported = 0usize;
+        let mut errors = Vec::new();
+        for file in files {
+            if let Some(name) = file.file_stem().and_then(|s| s.to_str()) {
+                let path = role_path(root, &target, name);
+                match fs::copy(file, &path) {
+                    Ok(_) => imported += 1,
+                    Err(err) => errors.push(format!("导入 `{name}` 失败: {err}")),
+                }
+            }
+        }
+        self.update_roles(root)
+            .map_err(|err| format!("刷新角色列表失败: {err}"))?;
+        self.status = Some(if !errors.is_empty() {
+            if imported > 0 {
+                format!(
+                    "成功导入 {imported} 个角色，但部分失败：{}",
+                    errors.join("；")
+                )
+            } else {
+                errors.join("；")
+            }
+        } else if imported > 0 {
+            format!("成功导入 {imported} 个角色")
+        } else {
+            "未导入任何角色".to_string()
+        });
+        Ok(())
+    }
+
+    fn current_entry(&self) -> Option<&RoleEntry> {
+        let selected = self.selected_role.as_ref()?;
+        self.roles.iter().find(|entry| &entry.name == selected)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RoleEntry {
+    pub name: String,
+    pub category: String,
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChapterPreviewState {
+    pub chapters: Vec<u32>,
+    pub selected: Option<u32>,
+    pub status: Option<String>,
+}
+
+impl ChapterPreviewState {
+    pub fn new() -> Self {
+        Self {
+            chapters: Vec::new(),
+            selected: None,
+            status: None,
+        }
+    }
+
+    pub fn refresh(&mut self, root: &Path) -> io::Result<()> {
+        let chapters_dir = root.join(CHAPTERS_DIR);
+        if !chapters_dir.exists() {
+            self.chapters.clear();
+            self.selected = None;
+            return Ok(());
+        }
+        let mut numbers = Vec::new();
+        for entry in fs::read_dir(&chapters_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if let Some(file_name) = path.file_name().and_then(|s| s.to_str()) {
+                if let Some(num) = parse_chapter_filename(file_name) {
+                    numbers.push(num);
+                }
+            }
+        }
+        numbers.sort_unstable();
+        self.chapters = numbers;
+        if let Some(selected) = self.selected {
+            if !self.chapters.contains(&selected) {
+                self.selected = self.chapters.first().copied();
+            }
+        } else {
+            self.selected = self.chapters.first().copied();
+        }
+        Ok(())
+    }
+
+    pub fn load(&mut self, chapter: u32, root: &Path) -> io::Result<String> {
+        let path = chapter_path(root, chapter);
+        fs::read_to_string(&path)
+    }
+
+    pub fn save(&self, chapter: u32, root: &Path, content: &str) -> io::Result<()> {
+        let path = chapter_path(root, chapter);
+        fs::create_dir_all(path.parent().unwrap())?;
+        fs::write(&path, content)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LogPanelState {
+    records: VecDeque<LogRecord>,
+    capacity: usize,
+}
+
+impl LogPanelState {
+    pub fn new() -> Self {
+        Self {
+            records: VecDeque::new(),
+            capacity: 500,
+        }
+    }
+
+    pub fn push(&mut self, record: LogRecord) {
+        if self.records.len() >= self.capacity {
+            self.records.pop_front();
+        }
+        self.records.push_back(record);
+    }
+
+    pub fn clear(&mut self) {
+        self.records.clear();
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &LogRecord> {
+        self.records.iter()
+    }
+}
+
+fn ensure_role_library(root: &Path) -> io::Result<()> {
+    fs::create_dir_all(root.join(ROLE_LIBRARY_DIR).join(ROLE_LIBRARY_ALL))
+}
+
+fn ensure_category(root: &Path, category: &str) -> io::Result<()> {
+    fs::create_dir_all(root.join(ROLE_LIBRARY_DIR).join(category))
+}
+
+fn collect_categories(root: &Path) -> Vec<String> {
+    let mut categories = vec![ROLE_LIBRARY_ALL.to_string()];
+    let role_dir = root.join(ROLE_LIBRARY_DIR);
+    if let Ok(entries) = fs::read_dir(&role_dir) {
+        for entry in entries.flatten() {
+            if let Ok(file_type) = entry.file_type() {
+                if file_type.is_dir() {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    if name != ROLE_LIBRARY_ALL {
+                        categories.push(name);
+                    }
+                }
+            }
+        }
+    }
+    categories.sort();
+    categories
+}
+
+fn collect_roles(root: &Path, category: &str) -> io::Result<Vec<RoleEntry>> {
+    let mut roles = Vec::new();
+    if category == ROLE_LIBRARY_ALL {
+        for entry in collect_categories(root) {
+            if entry == ROLE_LIBRARY_ALL {
+                continue;
+            }
+            roles.extend(collect_roles(root, &entry)?);
+        }
+    } else {
+        let dir = root.join(ROLE_LIBRARY_DIR).join(category);
+        if dir.exists() {
+            for entry in fs::read_dir(&dir)? {
+                let entry = entry?;
+                if entry.file_type()?.is_file() {
+                    if let Some(name) = entry.path().file_stem().and_then(|s| s.to_str()) {
+                        roles.push(RoleEntry {
+                            name: name.to_string(),
+                            category: category.to_string(),
+                            path: entry.path(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    roles.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(roles)
+}
+
+fn role_path(root: &Path, category: &str, name: &str) -> PathBuf {
+    root.join(ROLE_LIBRARY_DIR)
+        .join(category)
+        .join(format!("{name}.txt"))
+}
+
+fn parse_chapter_filename(name: &str) -> Option<u32> {
+    if let Some(stripped) = name.strip_prefix("chapter_") {
+        let stripped = stripped.strip_suffix(".txt").unwrap_or(stripped);
+        stripped.parse().ok()
+    } else {
+        None
+    }
+}
+
+fn chapter_path(root: &Path, chapter: u32) -> PathBuf {
+    root.join(CHAPTERS_DIR)
+        .join(format!("chapter_{chapter}.txt"))
+}

--- a/crates/ui/src/tasks.rs
+++ b/crates/ui/src/tasks.rs
@@ -1,0 +1,728 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+
+use novel_adapters::{
+    create_embedding_adapter, create_llm_adapter, import_knowledge_file, load_vector_store,
+    update_vector_store, AdapterError, VectorStoreConfig,
+};
+use novel_core::architecture::{ArchitectureRequest, ArchitectureService};
+use novel_core::blueprint::{
+    ChapterBlueprint, ChapterBlueprintRequest, ChapterBlueprintService, BLUEPRINT_FILE_NAME,
+};
+use novel_core::chapter::finalization::{ChapterFinalizer, FinalizeChapterRequest, FinalizeError};
+use novel_core::chapter::{ChapterDraft, ChapterPromptRequest, ChapterService, KnowledgeBase};
+use novel_core::config::{ConfigError, ConfigStore, NovelConfig};
+use novel_core::logging::{LogLevel, LogRecord, LogSink};
+use novel_core::prompts::{PromptError, PromptRegistry};
+use thiserror::Error;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+pub type EventSender = UnboundedSender<TaskEvent>;
+
+#[derive(Clone, Debug)]
+pub enum TaskCommand {
+    TestLlm(TestLlmCommand),
+    TestEmbedding(TestEmbeddingCommand),
+    GenerateArchitecture(GenerateArchitectureCommand),
+    GenerateBlueprint(GenerateBlueprintCommand),
+    BuildChapterPrompt(BuildChapterPromptCommand),
+    GenerateChapterDraft(GenerateChapterDraftCommand),
+    FinalizeChapter(FinalizeChapterCommand),
+    ImportKnowledge(ImportKnowledgeCommand),
+}
+
+impl TaskCommand {
+    pub fn kind(&self) -> TaskKind {
+        match self {
+            TaskCommand::TestLlm(_) => TaskKind::TestLlm,
+            TaskCommand::TestEmbedding(_) => TaskKind::TestEmbedding,
+            TaskCommand::GenerateArchitecture(_) => TaskKind::GenerateArchitecture,
+            TaskCommand::GenerateBlueprint(_) => TaskKind::GenerateBlueprint,
+            TaskCommand::BuildChapterPrompt(_) => TaskKind::BuildChapterPrompt,
+            TaskCommand::GenerateChapterDraft(_) => TaskKind::GenerateChapterDraft,
+            TaskCommand::FinalizeChapter(_) => TaskKind::FinalizeChapter,
+            TaskCommand::ImportKnowledge(_) => TaskKind::ImportKnowledge,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TaskKind {
+    TestLlm,
+    TestEmbedding,
+    GenerateArchitecture,
+    GenerateBlueprint,
+    BuildChapterPrompt,
+    GenerateChapterDraft,
+    FinalizeChapter,
+    ImportKnowledge,
+}
+
+impl TaskKind {
+    pub fn label(&self) -> &'static str {
+        match self {
+            TaskKind::TestLlm => "测试 LLM 配置",
+            TaskKind::TestEmbedding => "测试 Embedding 配置",
+            TaskKind::GenerateArchitecture => "生成小说架构",
+            TaskKind::GenerateBlueprint => "生成章节蓝图",
+            TaskKind::BuildChapterPrompt => "构建章节提示词",
+            TaskKind::GenerateChapterDraft => "生成章节草稿",
+            TaskKind::FinalizeChapter => "章节定稿",
+            TaskKind::ImportKnowledge => "导入知识库",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TestLlmCommand {
+    pub config_path: PathBuf,
+    pub interface: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TestEmbeddingCommand {
+    pub config_path: PathBuf,
+    pub interface: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct GenerateArchitectureCommand {
+    pub config_path: PathBuf,
+    pub output_dir: PathBuf,
+    pub topic: String,
+    pub genre: String,
+    pub number_of_chapters: u32,
+    pub word_number: u32,
+    pub user_guidance: String,
+    pub llm_interface: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct GenerateBlueprintCommand {
+    pub config_path: PathBuf,
+    pub output_dir: PathBuf,
+    pub number_of_chapters: u32,
+    pub max_tokens: u32,
+    pub user_guidance: String,
+    pub llm_interface: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BuildChapterPromptCommand {
+    pub config_path: PathBuf,
+    pub output_dir: PathBuf,
+    pub chapter_number: u32,
+    pub word_number: u32,
+    pub user_guidance: String,
+    pub characters_involved: String,
+    pub key_items: String,
+    pub scene_location: String,
+    pub time_constraint: String,
+    pub embedding_retrieval_k: usize,
+    pub history_chapter_count: usize,
+    pub llm_interface: Option<String>,
+    pub embedding_interface: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct GenerateChapterDraftCommand {
+    pub base: BuildChapterPromptCommand,
+    pub custom_prompt: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct FinalizeChapterCommand {
+    pub config_path: PathBuf,
+    pub output_dir: PathBuf,
+    pub chapter_number: u32,
+    pub llm_interface: Option<String>,
+    pub embedding_interface: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ImportKnowledgeCommand {
+    pub config_path: PathBuf,
+    pub output_dir: PathBuf,
+    pub file: PathBuf,
+    pub embedding_interface: Option<String>,
+    pub vector_url: String,
+    pub collection: String,
+    pub api_key: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct TaskController {
+    sender: UnboundedSender<TaskCommand>,
+    receiver: UnboundedReceiver<TaskEvent>,
+    _worker: thread::JoinHandle<()>,
+}
+
+impl TaskController {
+    pub fn new() -> Self {
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let worker_tx = event_tx.clone();
+
+        let handle = thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build runtime");
+
+            runtime.block_on(async move {
+                while let Some(command) = command_rx.recv().await {
+                    let sender = worker_tx.clone();
+                    tokio::spawn(run_command(command, sender));
+                }
+            });
+        });
+
+        Self {
+            sender: command_tx,
+            receiver: event_rx,
+            _worker: handle,
+        }
+    }
+
+    pub fn send(&self, command: TaskCommand) -> Result<(), TaskSendError> {
+        self.sender
+            .send(command)
+            .map_err(|_| TaskSendError::ChannelClosed)
+    }
+
+    pub fn try_recv(&mut self) -> Option<TaskEvent> {
+        self.receiver.try_recv().ok()
+    }
+}
+
+impl Default for TaskController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TaskSendError {
+    #[error("任务通道已关闭")]
+    ChannelClosed,
+}
+
+#[derive(Debug, Error)]
+pub enum TaskError {
+    #[error("配置错误: {0}")]
+    Config(#[from] ConfigError),
+    #[error("适配器错误: {0}")]
+    Adapter(#[from] AdapterError),
+    #[error("提示词错误: {0}")]
+    Prompt(#[from] PromptError),
+    #[error("蓝图生成错误: {0}")]
+    Blueprint(#[from] novel_core::blueprint::BlueprintError),
+    #[error("章节处理错误: {0}")]
+    Chapter(#[from] novel_core::chapter::ChapterError),
+    #[error("章节定稿错误: {0}")]
+    Finalize(#[from] FinalizeError),
+    #[error("语言模型错误: {0}")]
+    Model(#[from] novel_core::architecture::LanguageModelError),
+    #[error("Embedding 错误: {0}")]
+    Embedding(#[from] novel_core::embedding::EmbeddingModelError),
+    #[error("IO 错误: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("{0}")]
+    Custom(String),
+    #[error("后台任务崩溃: {0}")]
+    Join(String),
+}
+
+#[derive(Clone, Debug)]
+pub enum TaskEvent {
+    Log(LogRecord),
+    TaskStarted(TaskKind),
+    TaskFinished {
+        kind: TaskKind,
+        result: Result<(), TaskError>,
+    },
+    ChapterPromptReady {
+        number: u32,
+        prompt: String,
+        summary: String,
+        filtered_context: String,
+    },
+    ChapterDraftReady {
+        number: u32,
+        path: PathBuf,
+        content: String,
+        prompt: String,
+        summary: String,
+        filtered_context: String,
+    },
+    KnowledgeImportFinished {
+        inserted: usize,
+    },
+}
+
+struct ChannelLogSink {
+    sender: EventSender,
+}
+
+impl ChannelLogSink {
+    fn new(sender: EventSender) -> Self {
+        Self { sender }
+    }
+
+    fn emit(&self, record: LogRecord) {
+        let _ = self.sender.send(TaskEvent::Log(record));
+    }
+}
+
+impl LogSink for ChannelLogSink {
+    fn log(&self, record: LogRecord) {
+        self.emit(record);
+    }
+}
+
+async fn run_command(command: TaskCommand, sender: EventSender) {
+    let kind = command.kind();
+    let _ = sender.send(TaskEvent::TaskStarted(kind));
+    let sender_clone = sender.clone();
+    let result = tokio::task::spawn_blocking(move || execute_command(command, sender_clone)).await;
+    let outcome = match result {
+        Ok(res) => res,
+        Err(err) => Err(TaskError::Join(err.to_string())),
+    };
+    let _ = sender.send(TaskEvent::TaskFinished {
+        kind,
+        result: outcome,
+    });
+}
+
+fn execute_command(command: TaskCommand, sender: EventSender) -> Result<(), TaskError> {
+    match command {
+        TaskCommand::TestLlm(cmd) => run_test_llm(cmd, sender),
+        TaskCommand::TestEmbedding(cmd) => run_test_embedding(cmd, sender),
+        TaskCommand::GenerateArchitecture(cmd) => run_generate_architecture(cmd, sender),
+        TaskCommand::GenerateBlueprint(cmd) => run_generate_blueprint(cmd, sender),
+        TaskCommand::BuildChapterPrompt(cmd) => run_build_chapter_prompt(cmd, sender),
+        TaskCommand::GenerateChapterDraft(cmd) => run_generate_chapter_draft(cmd, sender),
+        TaskCommand::FinalizeChapter(cmd) => run_finalize_chapter(cmd, sender),
+        TaskCommand::ImportKnowledge(cmd) => run_import_knowledge(cmd, sender),
+    }
+}
+
+fn run_test_llm(command: TestLlmCommand, sender: EventSender) -> Result<(), TaskError> {
+    let mut store = ConfigStore::open(command.config_path)?;
+    store.ensure_recent_defaults();
+    let selected = resolve_llm_interface(&store, command.interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        format!("开始测试 LLM 配置：{selected}"),
+    ));
+    let profile = store
+        .config()
+        .get_llm_profile(&selected)
+        .cloned()
+        .ok_or_else(|| TaskError::Custom("缺少可用的 LLM 配置".to_string()))?;
+    sink.emit(LogRecord::new(
+        LogLevel::Debug,
+        format!(
+            "模型: {} | 接口模式: {} | Base URL: {}",
+            profile.model_name, profile.interface_format, profile.base_url
+        ),
+    ));
+    let adapter = create_llm_adapter(store.config(), &selected)?;
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        "发送测试提示词: Please reply 'OK'".to_string(),
+    ));
+    let response = adapter.invoke("Please reply 'OK'")?;
+    if response.trim().is_empty() {
+        sink.emit(LogRecord::new(
+            LogLevel::Error,
+            "❌ LLM配置测试失败：未获取到响应".to_string(),
+        ));
+        return Err(TaskError::Custom(
+            "LLM配置测试失败：未获取到响应".to_string(),
+        ));
+    }
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        "✅ LLM配置测试成功！".to_string(),
+    ));
+    sink.emit(LogRecord::new(
+        LogLevel::Debug,
+        format!("测试回复: {response}"),
+    ));
+    store.touch_llm_interface(selected);
+    store.save()?;
+    Ok(())
+}
+
+fn run_test_embedding(command: TestEmbeddingCommand, sender: EventSender) -> Result<(), TaskError> {
+    let mut store = ConfigStore::open(command.config_path)?;
+    store.ensure_recent_defaults();
+    let selected = resolve_embedding_interface(&store, command.interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        format!("开始测试 Embedding 配置：{selected}"),
+    ));
+    let profile = store
+        .config()
+        .get_embedding_profile(&selected)
+        .cloned()
+        .ok_or_else(|| TaskError::Custom("缺少可用的 Embedding 配置".to_string()))?;
+    sink.emit(LogRecord::new(
+        LogLevel::Debug,
+        format!(
+            "模型: {} | 接口模式: {} | Base URL: {}",
+            profile.model_name, profile.interface_format, profile.base_url
+        ),
+    ));
+    let adapter = create_embedding_adapter(store.config(), &selected)?;
+    let vector = adapter.embed_query("测试文本")?;
+    if vector.is_empty() {
+        sink.emit(LogRecord::new(
+            LogLevel::Error,
+            "❌ Embedding配置测试失败：未获取到向量".to_string(),
+        ));
+        return Err(TaskError::Custom(
+            "Embedding配置测试失败：未获取到向量".to_string(),
+        ));
+    }
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        format!("✅ Embedding配置测试成功！生成的向量维度: {}", vector.len()),
+    ));
+    store.touch_embedding_interface(selected);
+    store.save()?;
+    Ok(())
+}
+
+fn run_generate_architecture(
+    command: GenerateArchitectureCommand,
+    sender: EventSender,
+) -> Result<(), TaskError> {
+    let mut store = ConfigStore::open(command.config_path.clone())?;
+    store.ensure_recent_defaults();
+    let selected_llm = resolve_llm_interface(&store, command.llm_interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        format!("使用 LLM 接口：{selected_llm}"),
+    ));
+    let prompts = PromptRegistry::from_prompt_config(&store.config().prompts)?;
+    let service = ArchitectureService::new(&prompts, &sink);
+    let adapter = create_llm_adapter(store.config(), &selected_llm)?;
+    let request = ArchitectureRequest {
+        topic: command.topic.clone(),
+        genre: command.genre.clone(),
+        number_of_chapters: command.number_of_chapters,
+        word_number: command.word_number,
+        user_guidance: command.user_guidance.clone(),
+    };
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        "开始生成小说架构...".to_string(),
+    ));
+    service.generate(adapter.as_ref(), &command.output_dir, &request)?;
+    let mut novel = NovelConfig::default();
+    novel.topic = command.topic;
+    novel.genre = command.genre;
+    novel.num_chapters = command.number_of_chapters;
+    novel.word_number = command.word_number;
+    novel.filepath = command.output_dir.to_string_lossy().to_string();
+    store.config_mut().novel = novel;
+    store.touch_llm_interface(selected_llm);
+    store.save()?;
+    Ok(())
+}
+
+fn run_generate_blueprint(
+    command: GenerateBlueprintCommand,
+    sender: EventSender,
+) -> Result<(), TaskError> {
+    let mut store = ConfigStore::open(command.config_path.clone())?;
+    store.ensure_recent_defaults();
+    let selected_llm = resolve_llm_interface(&store, command.llm_interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        format!("使用 LLM 接口：{selected_llm}"),
+    ));
+    let prompts = PromptRegistry::from_prompt_config(&store.config().prompts)?;
+    let service = ChapterBlueprintService::new(&prompts, &sink);
+    let adapter = create_llm_adapter(store.config(), &selected_llm)?;
+    let request = ChapterBlueprintRequest::new(
+        command.number_of_chapters,
+        command.user_guidance.clone(),
+        command.max_tokens,
+    );
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        "开始生成章节蓝图...".to_string(),
+    ));
+    service.generate(adapter.as_ref(), &command.output_dir, &request)?;
+    store.config_mut().novel.num_chapters = command.number_of_chapters;
+    store.config_mut().novel.filepath = command.output_dir.to_string_lossy().to_string();
+    store.touch_llm_interface(selected_llm);
+    store.save()?;
+    Ok(())
+}
+
+fn run_build_chapter_prompt(
+    command: BuildChapterPromptCommand,
+    sender: EventSender,
+) -> Result<(), TaskError> {
+    let mut store = ConfigStore::open(command.config_path.clone())?;
+    store.ensure_recent_defaults();
+    let selected_llm = resolve_llm_interface(&store, command.llm_interface)?;
+    let selected_embedding = resolve_optional_embedding(&store, command.embedding_interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    let prompts = PromptRegistry::from_prompt_config(&store.config().prompts)?;
+    let service = ChapterService::new(&prompts, &sink);
+    let adapter = create_llm_adapter(store.config(), &selected_llm)?;
+    let embedding = if let Some(name) = &selected_embedding {
+        sink.emit(LogRecord::new(
+            LogLevel::Info,
+            format!("使用 Embedding 接口：{name}"),
+        ));
+        let adapter = create_embedding_adapter(store.config(), name)?;
+        Some((name.clone(), Arc::from(adapter)))
+    } else {
+        None
+    };
+    let knowledge = if let Some((_, arc)) = &embedding {
+        load_vector_store(&sink, Arc::clone(arc), &command.output_dir)?
+    } else {
+        None
+    };
+    let blueprint_path = command.output_dir.join(BLUEPRINT_FILE_NAME);
+    let blueprint_text = fs::read_to_string(&blueprint_path)?;
+    let blueprint = ChapterBlueprint::from_text(blueprint_text);
+    let mut request = ChapterPromptRequest::new(
+        &command.output_dir,
+        &blueprint,
+        command.chapter_number,
+        command.word_number,
+    );
+    request.user_guidance = command.user_guidance.clone();
+    request.characters_involved = command.characters_involved.clone();
+    request.key_items = command.key_items.clone();
+    request.scene_location = command.scene_location.clone();
+    request.time_constraint = command.time_constraint.clone();
+    request.embedding_retrieval_k = command.embedding_retrieval_k;
+    request.history_chapter_count = command.history_chapter_count;
+    let knowledge_ref = knowledge.as_ref().map(|store| store as &dyn KnowledgeBase);
+    let result = service.build_chapter_prompt(adapter.as_ref(), knowledge_ref, &request)?;
+    let _ = sender.send(TaskEvent::ChapterPromptReady {
+        number: command.chapter_number,
+        prompt: result.prompt_text.clone(),
+        summary: result.summary.clone(),
+        filtered_context: result.filtered_context.clone(),
+    });
+    store.touch_llm_interface(selected_llm);
+    if let Some((name, _)) = embedding {
+        store.touch_embedding_interface(name);
+    }
+    store.save()?;
+    Ok(())
+}
+
+fn run_generate_chapter_draft(
+    command: GenerateChapterDraftCommand,
+    sender: EventSender,
+) -> Result<(), TaskError> {
+    let base = command.base;
+    let mut store = ConfigStore::open(base.config_path.clone())?;
+    store.ensure_recent_defaults();
+    let selected_llm = resolve_llm_interface(&store, base.llm_interface)?;
+    let selected_embedding = resolve_optional_embedding(&store, base.embedding_interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    let prompts = PromptRegistry::from_prompt_config(&store.config().prompts)?;
+    let service = ChapterService::new(&prompts, &sink);
+    let adapter = create_llm_adapter(store.config(), &selected_llm)?;
+    let embedding = if let Some(name) = &selected_embedding {
+        sink.emit(LogRecord::new(
+            LogLevel::Info,
+            format!("使用 Embedding 接口：{name}"),
+        ));
+        let adapter = create_embedding_adapter(store.config(), name)?;
+        Some((name.clone(), Arc::from(adapter)))
+    } else {
+        None
+    };
+    let knowledge = if let Some((_, arc)) = &embedding {
+        load_vector_store(&sink, Arc::clone(arc), &base.output_dir)?
+    } else {
+        None
+    };
+    let blueprint_path = base.output_dir.join(BLUEPRINT_FILE_NAME);
+    let blueprint_text = fs::read_to_string(&blueprint_path)?;
+    let blueprint = ChapterBlueprint::from_text(blueprint_text);
+    let mut request = ChapterPromptRequest::new(
+        &base.output_dir,
+        &blueprint,
+        base.chapter_number,
+        base.word_number,
+    );
+    request.user_guidance = base.user_guidance.clone();
+    request.characters_involved = base.characters_involved.clone();
+    request.key_items = base.key_items.clone();
+    request.scene_location = base.scene_location.clone();
+    request.time_constraint = base.time_constraint.clone();
+    request.embedding_retrieval_k = base.embedding_retrieval_k;
+    request.history_chapter_count = base.history_chapter_count;
+    let knowledge_ref = knowledge.as_ref().map(|store| store as &dyn KnowledgeBase);
+    let custom_prompt = command.custom_prompt.as_deref();
+    let draft: ChapterDraft =
+        service.generate_chapter_draft(adapter.as_ref(), knowledge_ref, &request, custom_prompt)?;
+    let _ = sender.send(TaskEvent::ChapterDraftReady {
+        number: draft.chapter_number,
+        path: draft.path.clone(),
+        content: draft.content.clone(),
+        prompt: draft.prompt.clone(),
+        summary: draft.summary.clone(),
+        filtered_context: draft.filtered_context.clone(),
+    });
+    store.touch_llm_interface(selected_llm);
+    if let Some((name, _)) = embedding {
+        store.touch_embedding_interface(name);
+    }
+    store.save()?;
+    Ok(())
+}
+
+fn run_finalize_chapter(
+    command: FinalizeChapterCommand,
+    sender: EventSender,
+) -> Result<(), TaskError> {
+    let mut store = ConfigStore::open(command.config_path.clone())?;
+    store.ensure_recent_defaults();
+    let selected_llm = resolve_llm_interface(&store, command.llm_interface)?;
+    let selected_embedding = resolve_optional_embedding(&store, command.embedding_interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    let prompts = PromptRegistry::from_prompt_config(&store.config().prompts)?;
+    let finalizer = ChapterFinalizer::new(&prompts, &sink);
+    let adapter = create_llm_adapter(store.config(), &selected_llm)?;
+    let embedding = if let Some(name) = &selected_embedding {
+        sink.emit(LogRecord::new(
+            LogLevel::Info,
+            format!("使用 Embedding 接口：{name}"),
+        ));
+        let adapter = create_embedding_adapter(store.config(), name)?;
+        Some((name.clone(), Arc::from(adapter)))
+    } else {
+        None
+    };
+    let embedding_ref = embedding
+        .as_ref()
+        .map(|(_, adapter)| adapter.as_ref() as &dyn novel_core::embedding::EmbeddingModel);
+    let request = FinalizeChapterRequest {
+        output_dir: command.output_dir.clone(),
+        chapter_number: command.chapter_number,
+    };
+    let result = finalizer.finalize_chapter(adapter.as_ref(), embedding_ref, &request)?;
+    if let Some((name, arc)) = &embedding {
+        if let Some(store_vec) = load_vector_store(&sink, Arc::clone(arc), &command.output_dir)? {
+            let chapter_text = fs::read_to_string(&result.chapter_path)?;
+            let segments =
+                update_vector_store(&sink, &store_vec, command.chapter_number, &chapter_text)?;
+            sink.emit(LogRecord::new(
+                LogLevel::Info,
+                format!("向量库新增片段数量：{}", segments),
+            ));
+        } else {
+            sink.emit(LogRecord::new(
+                LogLevel::Warn,
+                "未找到向量库配置，定稿后未执行自动向量写入。".to_string(),
+            ));
+        }
+        store.touch_embedding_interface(name.clone());
+    }
+    store.touch_llm_interface(selected_llm);
+    store.save()?;
+    Ok(())
+}
+
+fn run_import_knowledge(
+    command: ImportKnowledgeCommand,
+    sender: EventSender,
+) -> Result<(), TaskError> {
+    let mut store = ConfigStore::open(command.config_path.clone())?;
+    store.ensure_recent_defaults();
+    let selected_embedding = resolve_embedding_interface(&store, command.embedding_interface)?;
+    let sink = ChannelLogSink::new(sender.clone());
+    sink.emit(LogRecord::new(
+        LogLevel::Info,
+        format!("开始导入知识库文件：{}", command.file.display()),
+    ));
+    let adapter = create_embedding_adapter(store.config(), &selected_embedding)?;
+    let arc: Arc<dyn novel_core::embedding::EmbeddingModel> = adapter.into();
+    let config = VectorStoreConfig {
+        base_url: command.vector_url.clone(),
+        collection_name: command.collection.clone(),
+        api_key: command.api_key.clone(),
+    };
+    let inserted = import_knowledge_file(&sink, arc, &command.output_dir, config, &command.file)?;
+    let _ = sender.send(TaskEvent::KnowledgeImportFinished { inserted });
+    store.touch_embedding_interface(selected_embedding);
+    store.save()?;
+    Ok(())
+}
+
+fn resolve_llm_interface(
+    store: &ConfigStore,
+    requested: Option<String>,
+) -> Result<String, TaskError> {
+    if let Some(interface) = requested {
+        return Ok(interface);
+    }
+    if let Some(name) = store.last_llm_interface() {
+        return Ok(name.to_string());
+    }
+    store
+        .config()
+        .llm_profiles
+        .keys()
+        .next()
+        .cloned()
+        .ok_or_else(|| TaskError::Custom("缺少可用的 LLM 配置".to_string()))
+}
+
+fn resolve_embedding_interface(
+    store: &ConfigStore,
+    requested: Option<String>,
+) -> Result<String, TaskError> {
+    if let Some(interface) = requested {
+        return Ok(interface);
+    }
+    if let Some(name) = store.last_embedding_interface() {
+        return Ok(name.to_string());
+    }
+    store
+        .config()
+        .embedding_profiles
+        .keys()
+        .next()
+        .cloned()
+        .ok_or_else(|| TaskError::Custom("缺少可用的 Embedding 配置".to_string()))
+}
+
+fn resolve_optional_embedding(
+    store: &ConfigStore,
+    requested: Option<String>,
+) -> Result<Option<String>, TaskError> {
+    if let Some(interface) = requested {
+        if interface.trim().is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(interface))
+        }
+    } else if let Some(name) = store.last_embedding_interface() {
+        Ok(Some(name.to_string()))
+    } else {
+        Ok(None)
+    }
+}

--- a/crates/ui/src/text_editor.rs
+++ b/crates/ui/src/text_editor.rs
@@ -1,0 +1,66 @@
+use egui::{Response, TextEdit, Ui};
+
+#[derive(Clone, Debug, Default)]
+pub struct TextEditorState {
+    text: String,
+    has_focus: bool,
+}
+
+impl TextEditorState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            has_focus: false,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.text.clear();
+    }
+
+    pub fn set_text(&mut self, text: impl Into<String>) {
+        self.text = text.into();
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn text_mut(&mut self) -> &mut String {
+        &mut self.text
+    }
+
+    pub fn insert_text(&mut self, snippet: &str) {
+        if !self.text.ends_with('\n') && !self.text.is_empty() {
+            self.text.push('\n');
+        }
+        self.text.push_str(snippet);
+    }
+
+    pub fn char_count(&self) -> usize {
+        self.text.chars().count()
+    }
+
+    pub fn word_count(&self) -> usize {
+        self.text.split_whitespace().count()
+    }
+
+    pub fn ui(&mut self, ui: &mut Ui, id_source: impl std::hash::Hash, rows: usize) -> Response {
+        let output = TextEdit::multiline(&mut self.text)
+            .id_source(id_source)
+            .desired_rows(rows)
+            .lock_focus(true)
+            .show(ui);
+
+        self.has_focus = output.response.has_focus();
+        output.response
+    }
+
+    pub fn has_focus(&self) -> bool {
+        self.has_focus
+    }
+}


### PR DESCRIPTION
## Summary
- add the `novel-ui` crate with an eframe application entry point
- implement the tabbed egui interface for configuration, novel parameters, role library, chapter preview, and logs
- integrate async task handling, filesystem operations, and reusable text editor state for prompt and chapter editing

## Testing
- cargo check *(fails: unable to reach crates.io because the environment blocks outbound network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdf92b07083338cbb6cfbc28f9ed3