### PR TITLE
Add Next.js scaffold for AI novel web app

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ai-novel-generator",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.49.1",
+    "clsx": "^2.1.1",
+    "next": "16.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.5.4",
+    "zustand": "^5.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "16.1.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/web/src/app/chapters/page.tsx
+++ b/web/src/app/chapters/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { useNovelStore } from "@/store/useNovelStore";
+
+const statusMap = {
+  pending: "待生成",
+  draft: "草稿",
+  review: "审校中",
+  final: "已定稿"
+};
+
+export default function ChaptersPage() {
+  const chapters = useNovelStore((state) => state.chapters);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">章节管理</h2>
+          <p className="text-sm text-slate-400">
+            章节生成、进度展示、字数统计与批量生成
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="secondary">批量生成</Button>
+          <Button>生成新章节</Button>
+        </div>
+      </header>
+
+      <section className="grid gap-4">
+        {chapters.map((chapter) => (
+          <Card key={chapter.id} className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-lg font-semibold text-white">{chapter.title}</p>
+                <p className="text-xs text-slate-400">{chapter.wordCount} 字</p>
+              </div>
+              <Badge>{statusMap[chapter.status]}</Badge>
+            </div>
+            <p className="text-sm text-slate-300">{chapter.summary}</p>
+            <div className="flex gap-2">
+              <Button variant="secondary">编辑</Button>
+              <Button variant="ghost">预览</Button>
+            </div>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/characters/page.tsx
+++ b/web/src/app/characters/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { useNovelStore } from "@/store/useNovelStore";
+
+const roleMap = {
+  protagonist: "主角",
+  supporting: "配角",
+  antagonist: "反派",
+  minor: "次要角色"
+};
+
+export default function CharactersPage() {
+  const characters = useNovelStore((state) => state.characters);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">角色管理</h2>
+          <p className="text-sm text-slate-400">
+            AI 生成角色档案，维护角色弧光与关系图谱
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="secondary">导入角色关系</Button>
+          <Button>AI 生成角色</Button>
+        </div>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {characters.map((character) => (
+          <Card key={character.id} className="space-y-4">
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="text-lg font-semibold text-white">{character.name}</p>
+                <p className="text-xs text-slate-400">年龄 {character.age}</p>
+              </div>
+              <Badge>{roleMap[character.role]}</Badge>
+            </div>
+            <div className="space-y-2 text-sm text-slate-300">
+              <p>外貌：{character.appearance}</p>
+              <p>性格：{character.personality}</p>
+              <p>背景：{character.background}</p>
+              <p>能力：{character.skills.join("、")}</p>
+              <p>人际关系：{character.relationships}</p>
+              <p>角色弧光：{character.arc}</p>
+              <p>说话风格：{character.voice}</p>
+            </div>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+
+import "@/styles/globals.css";
+import { Sidebar } from "@/components/navigation/sidebar";
+
+export const metadata: Metadata = {
+  title: "AI自动写小说系统",
+  description: "AI驱动的小说自动生成系统"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="zh">
+      <body className="min-h-screen">
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <main className="flex-1 bg-background p-8">
+            <div className="mx-auto max-w-6xl space-y-8">{children}</div>
+          </main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/src/app/outline/page.tsx
+++ b/web/src/app/outline/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { useNovelStore } from "@/store/useNovelStore";
+
+export default function OutlinePage() {
+  const outline = useNovelStore((state) => state.outline);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">大纲管理</h2>
+          <p className="text-sm text-slate-400">
+            管理三幕式或起承转合结构，标注高潮与伏笔
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="secondary">切换结构</Button>
+          <Button>AI 生成大纲</Button>
+        </div>
+      </header>
+
+      <section className="grid gap-4">
+        {outline.map((beat) => (
+          <Card key={beat.id} className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-slate-400">{beat.act}</p>
+                <p className="text-lg font-semibold text-white">{beat.title}</p>
+              </div>
+              <Button variant="ghost">编辑</Button>
+            </div>
+            <p className="text-sm text-slate-300">{beat.summary}</p>
+            <div className="grid gap-3 md:grid-cols-2 text-xs text-slate-400">
+              <div>
+                <p className="font-semibold text-slate-300">剧情亮点</p>
+                <ul className="list-disc pl-4">
+                  {beat.highlights.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <p className="font-semibold text-slate-300">伏笔与回收</p>
+                <ul className="list-disc pl-4">
+                  {beat.foreshadowing.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { ProjectCard } from "@/components/dashboard/project-card";
+import { StatCard } from "@/components/dashboard/stat-card";
+import { Button } from "@/components/ui/button";
+import { useNovelStore } from "@/store/useNovelStore";
+
+export default function HomePage() {
+  const projects = useNovelStore((state) => state.projects);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">项目仪表板</h2>
+          <p className="text-sm text-slate-400">
+            管理小说项目，查看进度和关键指标
+          </p>
+        </div>
+        <Button>新建项目</Button>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <StatCard label="活跃项目" value="2" helper="草稿与写作中项目" />
+        <StatCard label="已完成章节" value="18" helper="累计生成章节" />
+        <StatCard label="AI配置" value="2" helper="OpenAI / Gemini" />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {projects.map((project) => (
+          <ProjectCard key={project.id} project={project} />
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { useNovelStore } from "@/store/useNovelStore";
+
+export default function SettingsPage() {
+  const { aiConfigs, setActiveConfig } = useNovelStore((state) => ({
+    aiConfigs: state.aiConfigs,
+    setActiveConfig: state.setActiveConfig
+  }));
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">AI 配置管理</h2>
+          <p className="text-sm text-slate-400">
+            支持 OpenAI 与 Gemini API，支持多配置切换
+          </p>
+        </div>
+        <Button>新增配置</Button>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {aiConfigs.map((config) => (
+          <Card key={config.id} className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-slate-400">{config.provider.toUpperCase()}</p>
+                <p className="text-lg font-semibold text-white">{config.model}</p>
+              </div>
+              <Button
+                variant={config.isActive ? "secondary" : "ghost"}
+                onClick={() => setActiveConfig(config.id)}
+              >
+                {config.isActive ? "当前使用" : "切换"}
+              </Button>
+            </div>
+            <div className="grid gap-2 text-sm text-slate-300">
+              <p>Temperature: {config.temperature}</p>
+              <p>Max Tokens: {config.maxTokens}</p>
+            </div>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/worldbuilding/page.tsx
+++ b/web/src/app/worldbuilding/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { SectionCard } from "@/components/novel/section-card";
+import { useNovelStore } from "@/store/useNovelStore";
+
+export default function WorldbuildingPage() {
+  const world = useNovelStore((state) => state.worldbuilding);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">世界观管理</h2>
+          <p className="text-sm text-slate-400">
+            结构化记录世界观，支持 AI 重新生成与手动编辑
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="secondary">手动编辑</Button>
+          <Button>AI 重新生成</Button>
+        </div>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <SectionCard title="时代背景" description={world.era} />
+        <SectionCard title="权力/科技体系" description={world.powerSystem} />
+        <SectionCard title="文化习俗" description={world.culture} />
+        <SectionCard title="地理环境" description={world.geography} />
+        <SectionCard title="历史事件" description={world.history} />
+        <SectionCard title="补充说明" description={world.notes} />
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/dashboard/project-card.tsx
+++ b/web/src/components/dashboard/project-card.tsx
@@ -1,0 +1,38 @@
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import type { NovelProject } from "@/types/novel";
+
+const statusMap: Record<NovelProject["status"], { label: string; tone: "success" | "warning" | "neutral" }> = {
+  draft: { label: "草稿", tone: "neutral" },
+  writing: { label: "写作中", tone: "success" },
+  paused: { label: "暂停", tone: "warning" },
+  completed: { label: "已完成", tone: "success" }
+};
+
+export function ProjectCard({ project }: { project: NovelProject }) {
+  const status = statusMap[project.status];
+  return (
+    <Card className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-lg font-semibold text-white">{project.title}</p>
+          <p className="text-xs text-slate-400">{project.genre} · {project.style}</p>
+        </div>
+        <Badge tone={status.tone}>{status.label}</Badge>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>目标章节: {project.targetChapters}</span>
+          <span>更新于 {project.updatedAt}</span>
+        </div>
+        <div className="h-2 rounded-full bg-slate-800">
+          <div
+            className="h-2 rounded-full bg-accent"
+            style={{ width: `${project.progress}%` }}
+          />
+        </div>
+        <p className="text-xs text-slate-400">完成度 {project.progress}%</p>
+      </div>
+    </Card>
+  );
+}

--- a/web/src/components/dashboard/stat-card.tsx
+++ b/web/src/components/dashboard/stat-card.tsx
@@ -1,0 +1,17 @@
+import { Card } from "@/components/ui/card";
+
+interface StatCardProps {
+  label: string;
+  value: string;
+  helper: string;
+}
+
+export function StatCard({ label, value, helper }: StatCardProps) {
+  return (
+    <Card className="space-y-3">
+      <p className="text-sm text-slate-400">{label}</p>
+      <p className="text-3xl font-semibold text-white">{value}</p>
+      <p className="text-xs text-slate-400">{helper}</p>
+    </Card>
+  );
+}

--- a/web/src/components/navigation/sidebar.tsx
+++ b/web/src/components/navigation/sidebar.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+const links = [
+  { href: "/", label: "项目概览" },
+  { href: "/worldbuilding", label: "世界观" },
+  { href: "/characters", label: "角色" },
+  { href: "/outline", label: "大纲" },
+  { href: "/chapters", label: "章节" },
+  { href: "/settings", label: "AI配置" }
+];
+
+export function Sidebar() {
+  return (
+    <aside className="flex h-full w-64 flex-col gap-4 border-r border-muted bg-muted/40 p-6">
+      <div>
+        <p className="text-xs uppercase text-slate-400">AI自动写小说系统</p>
+        <h1 className="text-lg font-semibold">创作工作台</h1>
+      </div>
+      <nav className="flex flex-col gap-2">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="rounded-lg px-3 py-2 text-sm text-slate-200 transition hover:bg-muted"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+      <div className="mt-auto rounded-xl bg-slate-900/60 p-4 text-xs text-slate-300">
+        <p>版本: 0.1.0</p>
+        <p>支持 OpenAI / Gemini</p>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/novel/section-card.tsx
+++ b/web/src/components/novel/section-card.tsx
@@ -1,0 +1,15 @@
+import { Card } from "@/components/ui/card";
+
+interface SectionCardProps {
+  title: string;
+  description: string;
+}
+
+export function SectionCard({ title, description }: SectionCardProps) {
+  return (
+    <Card className="space-y-3">
+      <p className="text-sm text-slate-400">{title}</p>
+      <p className="text-base text-white">{description}</p>
+    </Card>
+  );
+}

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+
+interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  tone?: "success" | "warning" | "neutral";
+}
+
+export function Badge({ className, tone = "neutral", ...props }: BadgeProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+        tone === "success" && "bg-emerald-500/20 text-emerald-200",
+        tone === "warning" && "bg-amber-500/20 text-amber-200",
+        tone === "neutral" && "bg-slate-500/20 text-slate-200",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "ghost";
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "primary", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-medium transition",
+          variant === "primary" &&
+            "bg-accent text-white shadow hover:bg-indigo-500",
+          variant === "secondary" &&
+            "bg-muted text-foreground hover:bg-slate-700",
+          variant === "ghost" && "bg-transparent text-foreground hover:bg-muted",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button };

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils";
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className, ...props }: CardProps) {
+  return <div className={cn("card p-6", className)} {...props} />;
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/web/src/store/useNovelStore.ts
+++ b/web/src/store/useNovelStore.ts
@@ -1,0 +1,146 @@
+import { create } from "zustand";
+import type {
+  AIConfig,
+  ChapterPlan,
+  CharacterProfile,
+  NovelProject,
+  OutlineBeat,
+  WorldbuildingProfile
+} from "@/types/novel";
+
+interface NovelState {
+  projects: NovelProject[];
+  worldbuilding: WorldbuildingProfile;
+  characters: CharacterProfile[];
+  outline: OutlineBeat[];
+  chapters: ChapterPlan[];
+  aiConfigs: AIConfig[];
+  setActiveConfig: (id: string) => void;
+}
+
+export const useNovelStore = create<NovelState>((set) => ({
+  projects: [
+    {
+      id: "project-1",
+      title: "雾隐城纪事",
+      genre: "奇幻",
+      style: "史诗 + 悬疑",
+      targetChapters: 48,
+      status: "writing",
+      updatedAt: "2024-03-18",
+      progress: 62
+    },
+    {
+      id: "project-2",
+      title: "星轨边境",
+      genre: "科幻",
+      style: "硬科幻 + 成长",
+      targetChapters: 36,
+      status: "draft",
+      updatedAt: "2024-03-12",
+      progress: 18
+    }
+  ],
+  worldbuilding: {
+    era: "蒸汽与秘术并行的第二帝国时期",
+    powerSystem: "符文矩阵 + 以太驱动装置",
+    culture: "贵族议会与工坊联盟并存，强调契约与血统",
+    geography: "巨型浮空群岛与深渊矿脉共存",
+    history: "旧王朝覆灭后，新议会与军工财团分权",
+    notes: "世界观说明支持结构化 JSON 与富文本描述。"
+  },
+  characters: [
+    {
+      id: "char-1",
+      name: "林岚",
+      age: "24",
+      appearance: "银发短发，左眼带符文单片镜",
+      personality: "理性冷静但内心执着",
+      background: "工坊联盟的前侦察官",
+      skills: ["符文破解", "机巧战术", "谈判"],
+      relationships: "与反派家族有隐秘的血缘线索",
+      arc: "从怀疑体制到重建秩序",
+      voice: "言语简洁，偏向命令式",
+      role: "protagonist"
+    },
+    {
+      id: "char-2",
+      name: "席恩",
+      age: "31",
+      appearance: "深色长发，披风缀有旧王朝徽章",
+      personality: "强势、战略思维",
+      background: "旧王朝遗民领袖",
+      skills: ["政治博弈", "剑术", "情报网络"],
+      relationships: "与主角保持互相利用的脆弱同盟",
+      arc: "复辟信念与个人救赎的拉扯",
+      voice: "用词优雅，带暗示性",
+      role: "antagonist"
+    }
+  ],
+  outline: [
+    {
+      id: "beat-1",
+      act: "第一幕",
+      title: "雾隐城的信号",
+      summary: "主角收到失踪导师留下的密电，触发调查。",
+      highlights: ["城市停摆", "导师留言"],
+      foreshadowing: ["浮空群岛失衡", "议会阴影"]
+    },
+    {
+      id: "beat-2",
+      act: "第二幕",
+      title: "深渊矿脉的交易",
+      summary: "主角深入矿脉，与地下势力达成交易。",
+      highlights: ["权力体系冲突", "盟友背叛"],
+      foreshadowing: ["核心装置曝光"]
+    }
+  ],
+  chapters: [
+    {
+      id: "chapter-1",
+      title: "序章：雾隐的钟声",
+      status: "final",
+      wordCount: 3200,
+      summary: "引出世界观与主角的现状。"
+    },
+    {
+      id: "chapter-2",
+      title: "第一章：碎裂的符文",
+      status: "draft",
+      wordCount: 1800,
+      summary: "主角调查符文异常，获取初步线索。"
+    },
+    {
+      id: "chapter-3",
+      title: "第二章：暗影交易",
+      status: "pending",
+      wordCount: 0,
+      summary: "为揭示地下势力铺垫。"
+    }
+  ],
+  aiConfigs: [
+    {
+      id: "openai-1",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      temperature: 0.7,
+      maxTokens: 4096,
+      isActive: true
+    },
+    {
+      id: "gemini-1",
+      provider: "gemini",
+      model: "gemini-1.5-pro",
+      temperature: 0.6,
+      maxTokens: 2048,
+      isActive: false
+    }
+  ],
+  setActiveConfig: (id) =>
+    set((state) => ({
+      aiConfigs: state.aiConfigs.map((config) => ({
+        ...config,
+        isActive: config.id === id
+      }))
+    }))
+}));

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+.card {
+  @apply rounded-2xl border border-muted bg-card shadow-lg;
+}
+
+.section-title {
+  @apply text-xl font-semibold;
+}

--- a/web/src/types/novel.ts
+++ b/web/src/types/novel.ts
@@ -1,0 +1,63 @@
+export type ProjectStatus = "draft" | "writing" | "paused" | "completed";
+
+export interface NovelProject {
+  id: string;
+  title: string;
+  genre: string;
+  style: string;
+  targetChapters: number;
+  status: ProjectStatus;
+  updatedAt: string;
+  progress: number;
+}
+
+export interface WorldbuildingProfile {
+  era: string;
+  powerSystem: string;
+  culture: string;
+  geography: string;
+  history: string;
+  notes: string;
+}
+
+export type CharacterRole = "protagonist" | "supporting" | "antagonist" | "minor";
+
+export interface CharacterProfile {
+  id: string;
+  name: string;
+  age: string;
+  appearance: string;
+  personality: string;
+  background: string;
+  skills: string[];
+  relationships: string;
+  arc: string;
+  voice: string;
+  role: CharacterRole;
+}
+
+export interface OutlineBeat {
+  id: string;
+  act: string;
+  title: string;
+  summary: string;
+  highlights: string[];
+  foreshadowing: string[];
+}
+
+export interface ChapterPlan {
+  id: string;
+  title: string;
+  status: "pending" | "draft" | "review" | "final";
+  wordCount: number;
+  summary: string;
+}
+
+export interface AIConfig {
+  id: string;
+  provider: "openai" | "gemini";
+  model: string;
+  temperature: number;
+  maxTokens: number;
+  isActive: boolean;
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+    "./src/lib/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "#0b0f1a",
+        foreground: "#e6e9f5",
+        accent: "#6366f1",
+        muted: "#1f2433",
+        card: "#121826"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a web frontend scaffold for the AI-driven novel generator using Next.js (App Router) so UI and flow can be iterated independently of the Python backend.  
- Establish core modules for project, worldbuilding, character, outline, chapter, and AI configuration management to match feature requirements.  
- Include a simple client-side state store and TypeScript types to accelerate integration with LLM/back-end adapters.  
- Ensure a Tailwind-based design system and small set of reusable UI components for rapid prototyping.

### Description
- Add a new `web/` Next.js app with pages under `src/app/` for dashboard, `worldbuilding`, `characters`, `outline`, `chapters`, and `settings`.  
- Add shared UI components in `src/components/` (`ui`, `dashboard`, `navigation`, `novel`), utility `src/lib/utils.ts`, global styles `src/styles/globals.css`, and Tailwind config `tailwind.config.ts`.  
- Implement a client-side Zustand store `useNovelStore` with sample data and TypeScript domain models in `src/types/novel.ts`.  
- Add project configuration files including `package.json` (pinning `next` to `16.1.0`), `tsconfig.json`, `postcss.config.js`, `next.config.js`, and `.eslintrc.json`.

### Testing
- No automated tests were executed for this scaffold change.  
- The change is scaffold-only and intended to provide a working codebase to run `npm/pnpm install` and `next dev` in a proper environment for further verification.  
- Manual runtime/integration tests are pending once dependencies can be installed in the target environment.  
- Future PRs should add CI checks and unit/integration tests for components and store logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948229388648333891da3463d6f2741)